### PR TITLE
Add Comfy offload

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,21 @@ matching loader node — image→`LoadImage`, video/audio/3D→their loaders —
 **fill** a selected loader node, or **drag** a thumbnail onto the canvas. If no credentials are
 configured, the tab shows a connect panel (OAuth sign-in or paste an API key).
 
+### CustomComfy offload
+
+The **Run in Civitai** action submits the current graph as a `customComfy` workflow. Local model
+widgets are rewritten to AIRs when the model can be resolved by embedded metadata hash or computed
+hash, and installed custom node packs are advertised when a versioned nodepack AIR can be inferred.
+
+Use **Civitai/Offload/Civitai Offload Start** and **Civitai Offload End** to delimit a cloud region.
+Place `Start` to the left of the nodes to offload, put the normal Comfy workflow between the markers,
+include the user output node such as `SaveImage` inside that region, and place `End` to the right.
+Nodes after `End` are not included in the submitted customComfy job.
+
+The markers are selection hints for **Run in Civitai**. When the cloud job returns an output asset,
+the node pack imports that asset into local Comfy and queues the downstream nodes after `End` as a
+local continuation.
+
 ## Development
 
 Nodes are **generated** — never edit `civitai_comfy_nodes/generated/` by hand. To change

--- a/__init__.py
+++ b/__init__.py
@@ -1,8 +1,14 @@
-from .civitai_comfy_nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
+try:
+    from .civitai_comfy_nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
+except ImportError:  # pytest may import this wrapper as a top-level module
+    from civitai_comfy_nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 
 WEB_DIRECTORY = "./web"
 
 # Registers the /civitai/catalog/search proxy route when running inside ComfyUI; no-op otherwise.
-from .civitai_comfy_nodes import server_routes  # noqa: E402, F401
+try:
+    from .civitai_comfy_nodes import server_routes  # noqa: E402, F401
+except ImportError:  # pytest may import this wrapper as a top-level module
+    from civitai_comfy_nodes import server_routes  # noqa: E402, F401
 
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "WEB_DIRECTORY"]

--- a/civitai_comfy_nodes/client.py
+++ b/civitai_comfy_nodes/client.py
@@ -38,14 +38,17 @@ class OrchestrationClient:
         error.status_code = response.status_code
         raise error
 
-    def submit_workflow(self, step_type: str, input_payload: dict, *, wait: int = 5, whatif: bool = False) -> dict:
+    def submit_steps(self, steps: list[dict], *, wait: int = 5, whatif: bool = False) -> dict:
         params: dict = {"wait": wait}
         if whatif:
             params["whatif"] = "true"
         if self.config.allow_mature_content:
             params["hideMatureContent"] = "false"
-        body = {"steps": [{"$type": step_type, "input": input_payload}]}
+        body = {"steps": steps}
         return self._request("POST", "/v2/consumer/workflows", params=params, json=body).json()
+
+    def submit_workflow(self, step_type: str, input_payload: dict, *, wait: int = 5, whatif: bool = False) -> dict:
+        return self.submit_steps([{"$type": step_type, "input": input_payload}], wait=wait, whatif=whatif)
 
     def query_workflows(
         self,

--- a/civitai_comfy_nodes/nodes_manual.py
+++ b/civitai_comfy_nodes/nodes_manual.py
@@ -335,7 +335,6 @@ class CivitaiModelSelector:
             path = os.path.basename(full)  # folder-relative name the loader's combo resolves
         return (air, path)
 
-
 class CivitaiEmbeddingSelector:
     """Pick Civitai textual-inversion embeddings. Chain several (embeddings → embeddings) and wire
     the final `embeddings` output into a recipe node's `embeddings` input."""
@@ -364,6 +363,44 @@ class CivitaiEmbeddingSelector:
         return (stack,)
 
 
+class _CivitaiOffloadPassthrough:
+    CATEGORY = "Civitai/Offload"
+    FUNCTION = "mark"
+    RETURN_TYPES = (ANY_TYPE,)
+    RETURN_NAMES = ("value",)
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "region_id": (
+                    "STRING",
+                    {
+                        "default": "default",
+                        "tooltip": "Matching start/end markers delimit one Civitai offload region.",
+                    },
+                ),
+            },
+            "optional": {
+                "value": (
+                    ANY_TYPE,
+                    {"tooltip": "Passthrough value. The offload transformer removes this marker before submission."},
+                ),
+            },
+        }
+
+    def mark(self, region_id="default", value=None):
+        return (value,)
+
+
+class CivitaiOffloadStart(_CivitaiOffloadPassthrough):
+    """Passthrough marker that starts a graph region intended for Civitai customComfy offload."""
+
+
+class CivitaiOffloadEnd(_CivitaiOffloadPassthrough):
+    """Passthrough marker that ends a graph region intended for Civitai customComfy offload."""
+
+
 NODE_CLASS_MAPPINGS = {
     "CivitaiAuth": CivitaiAuth,
     "CivitaiChatSimple": CivitaiChatSimple,
@@ -371,6 +408,8 @@ NODE_CLASS_MAPPINGS = {
     "CivitaiControlNet": CivitaiControlNet,
     "CivitaiModelSelector": CivitaiModelSelector,
     "CivitaiEmbeddingSelector": CivitaiEmbeddingSelector,
+    "CivitaiOffloadStart": CivitaiOffloadStart,
+    "CivitaiOffloadEnd": CivitaiOffloadEnd,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -380,4 +419,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "CivitaiControlNet": "Civitai ControlNet",
     "CivitaiModelSelector": "Civitai Model Selector",
     "CivitaiEmbeddingSelector": "Civitai Embedding Selector",
+    "CivitaiOffloadStart": "Civitai Offload Start",
+    "CivitaiOffloadEnd": "Civitai Offload End",
 }

--- a/civitai_comfy_nodes/offload.py
+++ b/civitai_comfy_nodes/offload.py
@@ -1,0 +1,1188 @@
+"""Helpers for submitting local ComfyUI workflows as Civitai customComfy jobs.
+
+The code in here is deliberately import-safe outside ComfyUI. Runtime-only modules like
+folder_paths are imported lazily so pytest can exercise the inventory and transform logic.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import zlib
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+from urllib import parse
+
+import requests
+
+from . import oauth
+from .errors import CivitaiNodeError
+from .local_models import AIR_TYPE_FOLDERS, USER_AGENT
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - only hit on Python 3.10 runtimes
+    tomllib = None
+
+
+CIVITAI_BASE_URL = os.environ.get("CIVITAI_BASE_URL") or oauth.OAUTH_BASE
+MODEL_EXTENSIONS = {".safetensors", ".sft", ".ckpt", ".pt", ".pth", ".bin"}
+SAFETENSORS_MAX_HEADER = 16 * 1024 * 1024
+OFFLOAD_START_CLASS = "CivitaiOffloadStart"
+OFFLOAD_END_CLASS = "CivitaiOffloadEnd"
+OFFLOAD_MARKER_CLASSES = {OFFLOAD_START_CLASS, OFFLOAD_END_CLASS}
+OUTPUT_NODE_CLASSES = {
+    "PreviewImage",
+    "SaveAnimatedPNG",
+    "SaveAnimatedWEBP",
+    "SaveAudio",
+    "SaveAudioMP3",
+    "SaveAudioOpus",
+    "SaveGLB",
+    "SaveImage",
+    "SaveImageAdvanced",
+    "SaveVideo",
+    "SaveWEBM",
+}
+
+MODEL_WIDGET_FOLDERS = {
+    "ckpt_name": ("checkpoints",),
+    "lora_name": ("loras",),
+    "vae_name": ("vae",),
+    "control_net_name": ("controlnet",),
+    "controlnet_name": ("controlnet",),
+    "unet_name": ("diffusion_models",),
+    "clip_name": ("text_encoders", "clip"),
+    "clip_name1": ("text_encoders", "clip"),
+    "clip_name2": ("text_encoders", "clip"),
+    "clip_vision_name": ("clip_vision",),
+}
+MODEL_FOLDERS = tuple(dict.fromkeys(AIR_TYPE_FOLDERS.values()))
+AIR_RE = re.compile(r"^(?:urn:)?air:", re.IGNORECASE)
+HEX_RE = re.compile(r"[0-9a-fA-F]{8,128}")
+
+
+@dataclass
+class LocalModelRecord:
+    folder: str
+    name: str
+    path: str
+    hashes: dict[str, str] | None = None
+    hash_source: str | None = None
+    air: str | None = None
+    model_version_id: int | None = None
+    lookup_hash_type: str | None = None
+    lookup_hash: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class InstalledNodepack:
+    folder: str
+    registry_id: str | None
+    version: str | None
+    air: str | None
+    package_name: str | None = None
+    git_remote: str | None = None
+    git_commit: str | None = None
+    version_source: str | None = None
+    loaded: bool | None = None
+    loaded_node_count: int = 0
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class OffloadBuildResult:
+    steps: list[dict[str, Any]]
+    workflow: dict[str, Any]
+    resources: list[str]
+    warnings: list[str]
+    selected_node_ids: list[str]
+    included_node_ids: list[str]
+    model_resources: list[dict[str, Any]]
+    nodepack_resources: list[dict[str, Any]]
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class LocalContinuationBuildResult:
+    prompt: dict[str, Any]
+    bridge_node_id: str
+    tail_node_ids: list[str]
+    output_node_ids: list[str]
+    remote_source_node_ids: list[str]
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _clean_hash(value: Any) -> str | None:
+    if value is None:
+        return None
+    match = HEX_RE.search(str(value).strip())
+    if not match:
+        return None
+    return match.group(0).upper()
+
+
+def _hash_type_for_metadata_key(key: str, value: str) -> str | None:
+    normalized = re.sub(r"[^a-z0-9]", "", key.lower())
+    if normalized in {"sha256", "sha256hash", "filesha256", "fullsha256"}:
+        return "SHA256"
+    if normalized in {"autov1", "autov1hash"}:
+        return "AutoV1"
+    if normalized in {"autov2", "autov2hash", "sshslegacyhash"}:
+        return "AutoV2"
+    if normalized in {"autov3", "autov3hash", "sshsmodelhash"}:
+        return "AutoV3"
+    if "sha256" in normalized and len(value) == 64:
+        return "SHA256"
+    if "autov3" in normalized and len(value) == 64:
+        return "AutoV3"
+    if "autov2" in normalized and len(value) == 10:
+        return "AutoV2"
+    if "autov1" in normalized and len(value) == 8:
+        return "AutoV1"
+    if "hash" in normalized:
+        return "Hash"
+    return None
+
+
+def _read_safetensors_header(path: str | os.PathLike[str]) -> tuple[dict[str, Any] | None, int]:
+    try:
+        with open(path, "rb") as handle:
+            raw_length = handle.read(8)
+            if len(raw_length) != 8:
+                return None, 0
+            header_length = int.from_bytes(raw_length, "little")
+            if header_length <= 0 or header_length > SAFETENSORS_MAX_HEADER:
+                return None, 0
+            header_bytes = handle.read(header_length)
+    except OSError:
+        return None, 0
+    if len(header_bytes) != header_length:
+        return None, 0
+    try:
+        header = json.loads(header_bytes.rstrip(b"\0").decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None, 0
+    return header if isinstance(header, dict) else None, 8 + header_length
+
+
+def read_model_hashes_from_metadata(path: str | os.PathLike[str]) -> dict[str, str]:
+    """Read embedded hashes from safetensors metadata without hashing the model bytes."""
+    header, _payload_offset = _read_safetensors_header(path)
+    if not header:
+        return {}
+
+    items: list[tuple[str, Any]] = []
+    metadata = header.get("__metadata__")
+    if isinstance(metadata, dict):
+        items.extend(metadata.items())
+    items.extend((key, value) for key, value in header.items() if key != "__metadata__")
+
+    hashes: dict[str, str] = {}
+    for key, value in items:
+        cleaned = _clean_hash(value)
+        if not cleaned:
+            continue
+        hash_type = _hash_type_for_metadata_key(str(key), cleaned)
+        if hash_type and hash_type not in hashes:
+            hashes[hash_type] = cleaned
+    return hashes
+
+
+def _sha256_file(path: str | os.PathLike[str]) -> tuple[str, str]:
+    sha256 = hashlib.sha256()
+    crc = 0
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(4 * 1024 * 1024), b""):
+            sha256.update(chunk)
+            crc = zlib.crc32(chunk, crc)
+    return sha256.hexdigest().upper(), f"{crc & 0xFFFFFFFF:08X}"
+
+
+def _autov1_file(path: str | os.PathLike[str]) -> str | None:
+    try:
+        size = os.path.getsize(path)
+        if size < 0x100000 * 2:
+            return None
+        with open(path, "rb") as handle:
+            handle.seek(0x100000)
+            block = handle.read(0x10000)
+    except OSError:
+        return None
+    if len(block) != 0x10000:
+        return None
+    return hashlib.sha256(block).hexdigest().upper()[:8]
+
+
+def _autov3_safetensors_payload(path: str | os.PathLike[str]) -> str | None:
+    _header, payload_offset = _read_safetensors_header(path)
+    if not payload_offset:
+        return None
+    sha256 = hashlib.sha256()
+    with open(path, "rb") as handle:
+        handle.seek(payload_offset)
+        for chunk in iter(lambda: handle.read(4 * 1024 * 1024), b""):
+            sha256.update(chunk)
+    return sha256.hexdigest().upper()
+
+
+def compute_model_hashes(path: str | os.PathLike[str]) -> dict[str, str]:
+    """Compute the Civitai hash subset needed for local model AIR lookup.
+
+    Mirrors the scanner behavior for SHA256, AutoV1, AutoV2, AutoV3, and CRC32. Blake3 is omitted
+    because this package intentionally has no native hashing dependency.
+    """
+    sha256, crc32 = _sha256_file(path)
+    hashes = {"SHA256": sha256, "AutoV2": sha256[:10], "CRC32": crc32}
+    autov1 = _autov1_file(path)
+    if autov1:
+        hashes["AutoV1"] = autov1
+    autov3 = _autov3_safetensors_payload(path)
+    if autov3:
+        hashes["AutoV3"] = autov3
+    return hashes
+
+
+def get_model_hashes(path: str | os.PathLike[str], *, prefer_metadata: bool = True) -> tuple[dict[str, str], str]:
+    if prefer_metadata:
+        metadata_hashes = read_model_hashes_from_metadata(path)
+        if metadata_hashes:
+            return metadata_hashes, "metadata"
+    return compute_model_hashes(path), "computed"
+
+
+def _lookup_candidates(hashes: dict[str, str]) -> list[tuple[str, str]]:
+    order = ("SHA256", "AutoV3", "AutoV2", "AutoV1", "CRC32", "Hash")
+    candidates: list[tuple[str, str]] = []
+    for key in order:
+        value = hashes.get(key)
+        if value:
+            candidates.append((key, value))
+    for key, value in hashes.items():
+        if (key, value) not in candidates:
+            candidates.append((key, value))
+    return candidates
+
+
+def lookup_model_version_by_hash(
+    hash_value: str,
+    *,
+    token: str | None = None,
+    session: requests.Session | None = None,
+    civitai_base_url: str | None = None,
+) -> dict[str, Any] | None:
+    base = (civitai_base_url or CIVITAI_BASE_URL).rstrip("/")
+    headers = {"User-Agent": USER_AGENT}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    http = session or requests.Session()
+    response = http.get(
+        f"{base}/api/v1/model-versions/by-hash/{hash_value.upper()}",
+        headers=headers,
+        timeout=30,
+    )
+    if response.status_code == 404:
+        return None
+    if response.status_code >= 400:
+        raise CivitaiNodeError(f"Civitai hash lookup failed ({response.status_code}): {response.text}")
+    data = response.json()
+    return data if isinstance(data, dict) and data.get("air") else None
+
+
+def resolve_model_air(
+    path: str | os.PathLike[str],
+    *,
+    token: str | None = None,
+    session: requests.Session | None = None,
+    civitai_base_url: str | None = None,
+) -> LocalModelRecord | None:
+    """Resolve a local file to AIR using metadata hashes first, then computed hashes as fallback."""
+    metadata_hashes = read_model_hashes_from_metadata(path)
+    for hashes, source in ((metadata_hashes, "metadata"),):
+        if not hashes:
+            continue
+        for hash_type, hash_value in _lookup_candidates(hashes):
+            version = lookup_model_version_by_hash(
+                hash_value, token=token, session=session, civitai_base_url=civitai_base_url
+            )
+            if version:
+                return LocalModelRecord(
+                    folder="",
+                    name=Path(path).name,
+                    path=str(path),
+                    hashes=hashes,
+                    hash_source=source,
+                    air=version.get("air"),
+                    model_version_id=version.get("id"),
+                    lookup_hash_type=hash_type,
+                    lookup_hash=hash_value,
+                )
+
+    computed_hashes = compute_model_hashes(path)
+    for hash_type, hash_value in _lookup_candidates(computed_hashes):
+        version = lookup_model_version_by_hash(
+            hash_value, token=token, session=session, civitai_base_url=civitai_base_url
+        )
+        if version:
+            return LocalModelRecord(
+                folder="",
+                name=Path(path).name,
+                path=str(path),
+                hashes=computed_hashes,
+                hash_source="computed",
+                air=version.get("air"),
+                model_version_id=version.get("id"),
+                lookup_hash_type=hash_type,
+                lookup_hash=hash_value,
+            )
+    return None
+
+
+def _folder_paths_for(folder: str) -> list[str]:
+    try:
+        import folder_paths
+
+        return list(folder_paths.get_folder_paths(folder) or [])
+    except Exception:
+        return []
+
+
+def model_roots_by_folder(folders: tuple[str, ...] = MODEL_FOLDERS) -> dict[str, list[Path]]:
+    roots: dict[str, list[Path]] = {}
+    for folder in folders:
+        paths = [Path(path) for path in _folder_paths_for(folder)]
+        if paths:
+            roots[folder] = paths
+    return roots
+
+
+def scan_local_model_files(roots: dict[str, list[Path]] | None = None) -> list[LocalModelRecord]:
+    roots = roots if roots is not None else model_roots_by_folder()
+    records: list[LocalModelRecord] = []
+    seen: set[Path] = set()
+    for folder, paths in roots.items():
+        for root in paths:
+            if not root.exists():
+                continue
+            for path in sorted(root.rglob("*"), key=lambda item: str(item).lower()):
+                if not path.is_file() or path.suffix.lower() not in MODEL_EXTENSIONS:
+                    continue
+                try:
+                    resolved = path.resolve()
+                except OSError:
+                    continue
+                if resolved in seen:
+                    continue
+                seen.add(resolved)
+                try:
+                    name = str(path.relative_to(root))
+                except ValueError:
+                    name = path.name
+                records.append(LocalModelRecord(folder=folder, name=name, path=str(path)))
+    return records
+
+
+def _run_git(path: Path, args: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), *args],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=2,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _read_pyproject_metadata(path: Path) -> dict[str, str]:
+    pyproject = path / "pyproject.toml"
+    if not pyproject.exists() or tomllib is None:
+        return {}
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    project = data.get("project") if isinstance(data, dict) else None
+    if not isinstance(project, dict):
+        return {}
+    result: dict[str, str] = {}
+    for key in ("name", "version"):
+        value = str(project.get(key) or "").strip()
+        if value:
+            result[key] = value
+    urls = project.get("urls")
+    if isinstance(urls, dict):
+        for key in ("Repository", "Source", "Homepage", "repository", "source", "homepage"):
+            value = str(urls.get(key) or "").strip()
+            if value:
+                result["repository"] = value
+                break
+    return result
+
+
+def _read_package_json_metadata(path: Path) -> dict[str, str]:
+    package_json = path / "package.json"
+    if not package_json.exists():
+        return {}
+    try:
+        data = json.loads(package_json.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    result: dict[str, str] = {}
+    for key in ("name", "version", "repository"):
+        value = data.get(key)
+        if isinstance(value, dict):
+            value = value.get("url")
+        value = str(value or "").strip()
+        if value:
+            result[key] = value
+    return result
+
+
+def _github_registry_id_from_url(value: str | None) -> str | None:
+    if not value:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if text.startswith("github:"):
+        path = text.split(":", 1)[1]
+    elif text.startswith("git@github.com:"):
+        path = text.split(":", 1)[1]
+    else:
+        parsed = parse.urlparse(text)
+        host = (parsed.hostname or parsed.netloc).lower()
+        if host not in {"github.com", "www.github.com"}:
+            return None
+        path = parsed.path
+    parts = [part for part in path.strip("/").split("/") if part]
+    if len(parts) < 2:
+        return None
+    owner = parts[0].strip().lower()
+    repo = parts[1].strip()
+    if repo.endswith(".git"):
+        repo = repo[:-4]
+    repo = repo.lower()
+    if not owner or not repo:
+        return None
+    return f"{owner}/{repo}"
+
+
+def _clean_nodepack_version(value: str | None) -> str | None:
+    version = str(value or "").strip()
+    if not version:
+        return None
+    if version.startswith("v") and len(version) > 1 and version[1].isdigit():
+        version = version[1:]
+    if not any(ch.isdigit() for ch in version):
+        return None
+    if any(ch.isspace() for ch in version) or "@" in version:
+        return None
+    return version
+
+
+def _git_tag_version(path: Path) -> str | None:
+    output = _run_git(path, ["tag", "--points-at", "HEAD"])
+    if not output:
+        return None
+    for tag in output.splitlines():
+        version = _clean_nodepack_version(tag)
+        if version:
+            return version
+    return None
+
+
+def _infer_nodepack_air(registry_id: str | None, version: str | None) -> str | None:
+    if not registry_id or not version:
+        return None
+    return f"urn:air:comfy:nodepack:comfyregistry:{registry_id}@{version}"
+
+
+def _loaded_custom_node_state() -> dict[Path, int] | None:
+    nodes_module = sys.modules.get("nodes")
+    if nodes_module is None:
+        return None
+    loaded_dirs = getattr(nodes_module, "LOADED_MODULE_DIRS", None)
+    node_classes = getattr(nodes_module, "NODE_CLASS_MAPPINGS", None)
+    if not isinstance(loaded_dirs, dict):
+        return None
+    module_node_counts: dict[str, int] = {}
+    if isinstance(node_classes, dict):
+        for node_cls in node_classes.values():
+            relative_module = str(getattr(node_cls, "RELATIVE_PYTHON_MODULE", "") or "")
+            if not relative_module.startswith("custom_nodes."):
+                continue
+            module_name = relative_module.split(".", 2)[1]
+            module_node_counts[module_name] = module_node_counts.get(module_name, 0) + 1
+    state: dict[Path, int] = {}
+    for module_name, module_dir in loaded_dirs.items():
+        try:
+            resolved = Path(str(module_dir)).resolve()
+        except OSError:
+            continue
+        state[resolved] = module_node_counts.get(str(module_name), 0)
+    return state
+
+
+def _workflow_nodepack_folders(workflow: dict[str, Any]) -> set[str] | None:
+    """Return custom nodepack folders used by workflow class types when running inside ComfyUI."""
+    nodes_module = sys.modules.get("nodes")
+    if nodes_module is None:
+        return None
+    node_classes = getattr(nodes_module, "NODE_CLASS_MAPPINGS", None)
+    if not isinstance(node_classes, dict):
+        return None
+
+    folders: set[str] = set()
+    for node in workflow.values():
+        class_type = node.get("class_type")
+        if not class_type:
+            continue
+        node_class = node_classes.get(class_type)
+        if node_class is None:
+            continue
+        module_names = [
+            str(getattr(node_class, "RELATIVE_PYTHON_MODULE", "") or ""),
+            str(getattr(node_class, "__module__", "") or ""),
+        ]
+        for module_name in module_names:
+            if not module_name.startswith("custom_nodes."):
+                continue
+            parts = module_name.split(".")
+            if len(parts) >= 2 and parts[1]:
+                folders.add(parts[1])
+                break
+    return folders
+
+
+def custom_nodes_roots() -> list[Path]:
+    package_root = Path(__file__).resolve().parents[1]
+    candidates = [Path.cwd() / "custom_nodes"]
+    if package_root.parent.name == "custom_nodes":
+        candidates.append(package_root.parent)
+    candidates.append(package_root.parent / "custom_nodes")
+    candidates.append(package_root.parents[1] / "custom_nodes")
+    roots: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        if resolved in seen or not resolved.exists():
+            continue
+        seen.add(resolved)
+        roots.append(resolved)
+    return roots
+
+
+def scan_installed_nodepacks(root: Path | None = None) -> list[InstalledNodepack]:
+    roots = [root] if root is not None else custom_nodes_roots()
+    package_root = Path(__file__).resolve().parents[1]
+    nodepacks: list[InstalledNodepack] = []
+    seen: set[Path] = set()
+    loaded_state = _loaded_custom_node_state()
+    for root_path in roots:
+        if not root_path.exists():
+            continue
+        for path in sorted(root_path.iterdir(), key=lambda item: item.name.lower()):
+            if not path.is_dir() or path.name.startswith("."):
+                continue
+            if path.name in {"__pycache__", "civitai_p2p_worker", "civitai-comfy-nodes"}:
+                continue
+            try:
+                resolved = path.resolve()
+            except OSError:
+                continue
+            if resolved in seen or resolved == package_root.resolve():
+                continue
+            seen.add(resolved)
+
+            pyproject = _read_pyproject_metadata(path)
+            package_json = _read_package_json_metadata(path)
+            git_remote = _run_git(path, ["remote", "get-url", "origin"])
+
+            version_source = None
+            version = _clean_nodepack_version(pyproject.get("version"))
+            if version:
+                version_source = "pyproject"
+            if not version:
+                version = _clean_nodepack_version(package_json.get("version"))
+                if version:
+                    version_source = "packageJson"
+            if not version:
+                version = _git_tag_version(path)
+                if version:
+                    version_source = "gitTag"
+
+            if version_source == "pyproject":
+                repository_url = pyproject.get("repository") or git_remote or package_json.get("repository")
+            elif version_source == "packageJson":
+                repository_url = package_json.get("repository") or git_remote or pyproject.get("repository")
+            else:
+                repository_url = git_remote or pyproject.get("repository") or package_json.get("repository")
+            registry_id = _github_registry_id_from_url(repository_url)
+            air = _infer_nodepack_air(registry_id, version)
+            loaded_node_count = loaded_state.get(resolved, 0) if loaded_state is not None else 0
+            loaded = loaded_state is None or (resolved in loaded_state and loaded_node_count > 0)
+            nodepacks.append(
+                InstalledNodepack(
+                    folder=path.name,
+                    registry_id=registry_id,
+                    version=version,
+                    air=air,
+                    package_name=pyproject.get("name") or package_json.get("name"),
+                    git_remote=repository_url,
+                    git_commit=_run_git(path, ["rev-parse", "HEAD"]),
+                    version_source=version_source,
+                    loaded=None if loaded_state is None else loaded,
+                    loaded_node_count=loaded_node_count,
+                )
+            )
+    return nodepacks
+
+
+def _node_inputs(node: dict[str, Any]) -> dict[str, Any]:
+    inputs = node.get("inputs")
+    return inputs if isinstance(inputs, dict) else {}
+
+
+def _input_links(node: dict[str, Any]) -> list[tuple[str, int]]:
+    links: list[tuple[str, int]] = []
+    for value in _node_inputs(node).values():
+        if isinstance(value, list) and len(value) == 2 and isinstance(value[0], (str, int)):
+            try:
+                links.append((str(value[0]), int(value[1])))
+            except (TypeError, ValueError):
+                continue
+    return links
+
+
+def _ancestors(prompt: dict[str, Any], node_id: str) -> set[str]:
+    result: set[str] = set()
+
+    def visit(current: str) -> None:
+        if current in result or current not in prompt:
+            return
+        result.add(current)
+        for source_id, _slot in _input_links(prompt[current]):
+            visit(source_id)
+
+    visit(str(node_id))
+    return result
+
+
+def _downstream(prompt: dict[str, Any]) -> dict[str, set[str]]:
+    downstream: dict[str, set[str]] = {str(node_id): set() for node_id in prompt}
+    for node_id, node in prompt.items():
+        for source_id, _slot in _input_links(node):
+            downstream.setdefault(source_id, set()).add(str(node_id))
+    return downstream
+
+
+def _descendants(prompt: dict[str, Any], node_id: str) -> set[str]:
+    edges = _downstream(prompt)
+    result: set[str] = set()
+
+    def visit(current: str) -> None:
+        if current in result:
+            return
+        result.add(current)
+        for target in edges.get(current, set()):
+            visit(target)
+
+    visit(str(node_id))
+    return result
+
+
+def _region_node_ids(prompt: dict[str, Any]) -> set[str]:
+    starts: dict[str, list[str]] = {}
+    ends: dict[str, list[str]] = {}
+    for node_id, node in prompt.items():
+        class_type = node.get("class_type")
+        region_id = str(_node_inputs(node).get("region_id") or "default")
+        if class_type == OFFLOAD_START_CLASS:
+            starts.setdefault(region_id, []).append(str(node_id))
+        elif class_type == OFFLOAD_END_CLASS:
+            ends.setdefault(region_id, []).append(str(node_id))
+
+    selected: set[str] = set()
+    for region_id, start_ids in starts.items():
+        for start_id in start_ids:
+            for end_id in ends.get(region_id, []):
+                selected |= _descendants(prompt, start_id) & _ancestors(prompt, end_id)
+    return selected
+
+
+def _serialized_workflow_nodes(workflow: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(workflow, dict):
+        return []
+    nodes = workflow.get("nodes")
+    if isinstance(nodes, list):
+        return [node for node in nodes if isinstance(node, dict)]
+    nested = workflow.get("workflow")
+    if isinstance(nested, dict):
+        return _serialized_workflow_nodes(nested)
+    return []
+
+
+def _serialized_node_id(node: dict[str, Any]) -> str | None:
+    value = node.get("id")
+    if value is None:
+        return None
+    return str(value)
+
+
+def _serialized_node_class(node: dict[str, Any]) -> str:
+    return str(node.get("type") or node.get("class_type") or node.get("comfyClass") or "")
+
+
+def _serialized_node_pos(node: dict[str, Any]) -> tuple[float, float] | None:
+    pos = node.get("pos") or node.get("position")
+    if isinstance(pos, (list, tuple)) and len(pos) >= 2:
+        try:
+            return float(pos[0]), float(pos[1])
+        except (TypeError, ValueError):
+            return None
+    if isinstance(pos, dict):
+        try:
+            return float(pos.get("x")), float(pos.get("y"))
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _serialized_region_id(node: dict[str, Any]) -> str:
+    widgets = node.get("widgets_values")
+    if isinstance(widgets, list) and widgets:
+        value = str(widgets[0] or "").strip()
+        if value:
+            return value
+    widgets_by_name = node.get("widgets")
+    if isinstance(widgets_by_name, list):
+        for widget in widgets_by_name:
+            if not isinstance(widget, dict) or widget.get("name") != "region_id":
+                continue
+            value = str(widget.get("value") or "").strip()
+            if value:
+                return value
+    properties = node.get("properties")
+    if isinstance(properties, dict):
+        value = str(properties.get("region_id") or "").strip()
+        if value:
+            return value
+    return "default"
+
+
+def _visual_region_node_ids(prompt: dict[str, Any], workflow: dict[str, Any] | None) -> set[str]:
+    """Select API prompt nodes visually placed between matching Start/End nodes.
+
+    This supports the UX contract users expect on the canvas: put a Start marker to the left of the
+    offloadable subgraph, put the matching End marker to the right, and everything between those
+    markers becomes the submitted customComfy region. The markers do not need to be wired into the
+    Comfy execution graph, so local marker placement stays separate from model/data edges.
+    """
+    graph_nodes = _serialized_workflow_nodes(workflow)
+    if not graph_nodes:
+        return set()
+
+    starts: dict[str, list[dict[str, Any]]] = {}
+    ends: dict[str, list[dict[str, Any]]] = {}
+    nodes_by_id: dict[str, dict[str, Any]] = {}
+    for node in graph_nodes:
+        node_id = _serialized_node_id(node)
+        if node_id:
+            nodes_by_id[node_id] = node
+        class_type = _serialized_node_class(node)
+        if class_type == OFFLOAD_START_CLASS:
+            starts.setdefault(_serialized_region_id(node), []).append(node)
+        elif class_type == OFFLOAD_END_CLASS:
+            ends.setdefault(_serialized_region_id(node), []).append(node)
+
+    selected: set[str] = set()
+    for region_id, start_nodes in starts.items():
+        for start in start_nodes:
+            start_pos = _serialized_node_pos(start)
+            if start_pos is None:
+                continue
+            for end in ends.get(region_id, []):
+                end_pos = _serialized_node_pos(end)
+                if end_pos is None:
+                    continue
+                left, right = sorted((start_pos[0], end_pos[0]))
+                if left == right:
+                    continue
+                for node_id, node in nodes_by_id.items():
+                    if node_id not in prompt:
+                        continue
+                    class_type = _serialized_node_class(node)
+                    if class_type in OFFLOAD_MARKER_CLASSES:
+                        continue
+                    pos = _serialized_node_pos(node)
+                    if pos is not None and left < pos[0] < right:
+                        selected.add(node_id)
+    return selected
+
+
+def _normalize_prompt(prompt: dict[str, Any]) -> dict[str, Any]:
+    return {str(node_id): copy.deepcopy(node) for node_id, node in (prompt or {}).items() if isinstance(node, dict)}
+
+
+def _node_sort_key(node_id: str) -> tuple[int, int | str]:
+    return (0, int(node_id)) if str(node_id).isdigit() else (1, str(node_id))
+
+
+def _dependency_closure(prompt: dict[str, Any], node_ids: set[str]) -> set[str]:
+    included: set[str] = set()
+    for node_id in node_ids:
+        included |= _ancestors(prompt, node_id)
+    return included
+
+
+def _is_output_node(class_type: str) -> bool:
+    try:
+        nodes_module = sys.modules.get("nodes")
+        if nodes_module is None:
+            import nodes as nodes_module  # type: ignore[no-redef]
+        node_classes = getattr(nodes_module, "NODE_CLASS_MAPPINGS", None)
+        cls = node_classes.get(class_type) if isinstance(node_classes, dict) else None
+        if cls is not None:
+            return bool(getattr(cls, "OUTPUT_NODE", False))
+    except Exception:
+        pass
+    return class_type in OUTPUT_NODE_CLASSES
+
+
+def _user_output_nodes_within_region(prompt: dict[str, Any], included: set[str]) -> set[str]:
+    output_nodes: set[str] = set()
+    for node_id, node in prompt.items():
+        node_id = str(node_id)
+        if node_id in included or not _is_output_node(str(node.get("class_type") or "")):
+            continue
+        dependencies = _ancestors(prompt, node_id) - {node_id}
+        if any(prompt.get(dependency, {}).get("class_type") == OFFLOAD_END_CLASS for dependency in dependencies):
+            continue
+        if dependencies and dependencies <= included:
+            output_nodes.add(node_id)
+    return output_nodes
+
+
+def _replace_link_references(prompt: dict[str, Any], old_node_id: str, replacement: list[Any] | None) -> None:
+    for node in prompt.values():
+        for input_name, value in list(_node_inputs(node).items()):
+            if not (isinstance(value, list) and len(value) == 2 and str(value[0]) == old_node_id):
+                continue
+            if replacement is None:
+                del node["inputs"][input_name]
+            else:
+                node["inputs"][input_name] = copy.deepcopy(replacement)
+
+
+def strip_offload_markers(prompt: dict[str, Any]) -> dict[str, Any]:
+    """Remove passthrough marker nodes and rewire their output slot 0 to their `value` input."""
+    workflow = copy.deepcopy(prompt)
+    changed = True
+    while changed:
+        changed = False
+        for node_id, node in list(workflow.items()):
+            if node.get("class_type") not in OFFLOAD_MARKER_CLASSES:
+                continue
+            value = _node_inputs(node).get("value")
+            replacement = value if isinstance(value, list) and len(value) == 2 else None
+            _replace_link_references(workflow, str(node_id), replacement)
+            del workflow[node_id]
+            changed = True
+    return workflow
+
+
+def _dangling_links(prompt: dict[str, Any]) -> list[tuple[str, str]]:
+    dangling: list[tuple[str, str]] = []
+    ids = set(prompt)
+    for node_id, node in prompt.items():
+        for source_id, _slot in _input_links(node):
+            if source_id not in ids:
+                dangling.append((str(node_id), source_id))
+    return dangling
+
+
+def _unique_node_id(prompt: dict[str, Any], preferred: str) -> str:
+    if preferred not in prompt:
+        return preferred
+    numeric_ids = [int(node_id) for node_id in prompt if str(node_id).isdigit()]
+    return str((max(numeric_ids) if numeric_ids else 0) + 1)
+
+
+def build_local_continuation_prompt(
+    prompt: dict[str, Any],
+    *,
+    remote_node_ids: list[str],
+    imported_image_name: str,
+    bridge_node_id: str = "civitai_remote_asset",
+) -> LocalContinuationBuildResult | None:
+    """Build a local Comfy prompt for nodes downstream of the offloaded region.
+
+    Links that crossed from the offloaded subgraph into the local tail are rewritten to a LoadImage
+    bridge loaded from the remote customComfy asset. This is intentionally image-first because the
+    current customComfy asset contract only exposes file URLs, not typed socket values.
+    """
+    normalized = _normalize_prompt(prompt)
+    remote_ids = {str(node_id) for node_id in remote_node_ids if str(node_id) in normalized}
+    if not normalized or not remote_ids:
+        return None
+
+    downstream = _downstream(normalized)
+    tail_seed: set[str] = set()
+    remote_source_ids: set[str] = set()
+    for remote_id in remote_ids:
+        for target_id in downstream.get(remote_id, set()):
+            if target_id in remote_ids:
+                continue
+            tail_seed.add(target_id)
+            remote_source_ids.add(remote_id)
+    if not tail_seed:
+        return None
+
+    tail_descendants: set[str] = set()
+    for node_id in tail_seed:
+        tail_descendants |= _descendants(normalized, node_id)
+    tail_descendants -= remote_ids
+    if not tail_descendants:
+        return None
+
+    output_node_ids = {
+        node_id
+        for node_id in tail_descendants
+        if _is_output_node(str(normalized.get(node_id, {}).get("class_type") or ""))
+    }
+    target_ids = output_node_ids or tail_descendants
+    tail_ids = _dependency_closure(normalized, target_ids) - remote_ids
+    if not tail_ids:
+        return None
+
+    local_prompt = {
+        node_id: copy.deepcopy(normalized[node_id])
+        for node_id in sorted(tail_ids, key=_node_sort_key)
+    }
+    bridge_id = _unique_node_id({**normalized, **local_prompt}, bridge_node_id)
+    local_prompt = {
+        bridge_id: {"class_type": "LoadImage", "inputs": {"image": imported_image_name}},
+        **local_prompt,
+    }
+
+    for node in local_prompt.values():
+        for input_name, value in list(_node_inputs(node).items()):
+            if isinstance(value, list) and len(value) == 2 and str(value[0]) in remote_ids:
+                remote_source_ids.add(str(value[0]))
+                node["inputs"][input_name] = [bridge_id, 0]
+
+    dangling = _dangling_links(local_prompt)
+    if dangling:
+        refs = ", ".join(f"{node_id}->{source_id}" for node_id, source_id in dangling[:8])
+        raise CivitaiNodeError(f"Local continuation has inputs from unavailable nodes: {refs}")
+
+    return LocalContinuationBuildResult(
+        prompt=local_prompt,
+        bridge_node_id=bridge_id,
+        tail_node_ids=sorted(tail_ids, key=_node_sort_key),
+        output_node_ids=sorted(output_node_ids, key=_node_sort_key),
+        remote_source_node_ids=sorted(remote_source_ids, key=_node_sort_key),
+    )
+
+
+def _value_contains_air(value: Any, resources: set[str]) -> None:
+    if isinstance(value, str):
+        if AIR_RE.match(value.strip()):
+            resources.add(value.strip())
+    elif isinstance(value, list):
+        for item in value:
+            _value_contains_air(item, resources)
+    elif isinstance(value, dict):
+        for item in value.values():
+            _value_contains_air(item, resources)
+
+
+def _model_record_index(records: list[LocalModelRecord]) -> dict[tuple[str | None, str], LocalModelRecord]:
+    index: dict[tuple[str | None, str], LocalModelRecord] = {}
+    for record in records:
+        names = {record.name, Path(record.name).name, Path(record.path).name}
+        for name in names:
+            key_name = name.replace("\\", "/").lower()
+            index[(record.folder, key_name)] = record
+            index[(None, key_name)] = record
+    return index
+
+
+def _find_model_record(
+    value: str,
+    input_name: str,
+    records_by_name: dict[tuple[str | None, str], LocalModelRecord],
+) -> LocalModelRecord | None:
+    name = value.replace("\\", "/").lower()
+    folders = MODEL_WIDGET_FOLDERS.get(input_name, ())
+    for folder in folders:
+        record = records_by_name.get((folder, name)) or records_by_name.get((folder, Path(name).name))
+        if record:
+            return record
+    if Path(name).suffix.lower() in MODEL_EXTENSIONS or input_name in MODEL_WIDGET_FOLDERS:
+        return records_by_name.get((None, name)) or records_by_name.get((None, Path(name).name))
+    return None
+
+
+def _resolve_record_air(
+    record: LocalModelRecord,
+    *,
+    token: str | None,
+    session: requests.Session | None,
+    civitai_base_url: str | None,
+) -> LocalModelRecord | None:
+    if record.air:
+        return record
+    resolved = resolve_model_air(record.path, token=token, session=session, civitai_base_url=civitai_base_url)
+    if not resolved:
+        return None
+    resolved.folder = record.folder
+    resolved.name = record.name
+    return resolved
+
+
+def replace_local_models_with_airs(
+    workflow: dict[str, Any],
+    *,
+    model_records: list[LocalModelRecord],
+    resources: set[str],
+    token: str | None = None,
+    session: requests.Session | None = None,
+    civitai_base_url: str | None = None,
+) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+    rewritten = copy.deepcopy(workflow)
+    index = _model_record_index(model_records)
+    resolved_models: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    cache: dict[str, LocalModelRecord | None] = {}
+
+    for node in rewritten.values():
+        for input_name, value in list(_node_inputs(node).items()):
+            _value_contains_air(value, resources)
+            if not isinstance(value, str):
+                continue
+            if AIR_RE.match(value.strip()):
+                continue
+            record = _find_model_record(value, input_name, index)
+            if not record:
+                if input_name in MODEL_WIDGET_FOLDERS:
+                    warnings.append(
+                        f"Local model '{value}' on input '{input_name}' was not found in ComfyUI model dirs"
+                    )
+                continue
+            cache_key = record.path
+            resolved = cache.get(cache_key)
+            if cache_key not in cache:
+                resolved = _resolve_record_air(
+                    record, token=token, session=session, civitai_base_url=civitai_base_url
+                )
+                cache[cache_key] = resolved
+            if not resolved or not resolved.air:
+                warnings.append(f"Local model '{value}' could not be resolved to a Civitai AIR by hash")
+                continue
+            node["inputs"][input_name] = resolved.air
+            resources.add(resolved.air)
+            resolved_models.append(resolved.as_dict())
+    return rewritten, resolved_models, warnings
+
+
+def build_custom_comfy_offload(
+    prompt: dict[str, Any],
+    *,
+    selected_node_ids: list[str] | None = None,
+    workflow: dict[str, Any] | None = None,
+    model_records: list[LocalModelRecord] | None = None,
+    nodepacks: list[InstalledNodepack] | None = None,
+    token: str | None = None,
+    session: requests.Session | None = None,
+    civitai_base_url: str | None = None,
+) -> OffloadBuildResult:
+    normalized = _normalize_prompt(prompt)
+    if not normalized:
+        raise CivitaiNodeError("No ComfyUI prompt graph was provided")
+
+    explicit_selection = {str(node_id) for node_id in selected_node_ids or [] if str(node_id) in normalized}
+    region_selection = _region_node_ids(normalized)
+    visual_region_selection = set() if explicit_selection else _visual_region_node_ids(normalized, workflow)
+    selected = explicit_selection or visual_region_selection or region_selection or set(normalized)
+    included = _dependency_closure(normalized, selected)
+    if region_selection and not explicit_selection:
+        included |= _user_output_nodes_within_region(normalized, included)
+    subset = {
+        node_id: copy.deepcopy(normalized[node_id])
+        for node_id in sorted(included, key=_node_sort_key)
+    }
+    stripped = strip_offload_markers(subset)
+
+    dangling = _dangling_links(stripped)
+    if dangling:
+        refs = ", ".join(f"{node_id}->{source_id}" for node_id, source_id in dangling[:8])
+        raise CivitaiNodeError(f"Offload selection has inputs from nodes outside the submitted graph: {refs}")
+
+    resources: set[str] = set()
+    for node in stripped.values():
+        _value_contains_air(_node_inputs(node), resources)
+
+    model_records = model_records if model_records is not None else scan_local_model_files()
+    rewritten, resolved_models, model_warnings = replace_local_models_with_airs(
+        stripped,
+        model_records=model_records,
+        resources=resources,
+        token=token,
+        session=session,
+        civitai_base_url=civitai_base_url,
+    )
+
+    nodepacks = nodepacks if nodepacks is not None else scan_installed_nodepacks()
+    used_nodepack_folders = _workflow_nodepack_folders(rewritten)
+    nodepack_resources = []
+    for nodepack in nodepacks:
+        if not nodepack.air or nodepack.loaded is False:
+            continue
+        if used_nodepack_folders is not None and nodepack.folder not in used_nodepack_folders:
+            continue
+        resources.add(nodepack.air)
+        nodepack_resources.append(nodepack.as_dict())
+
+    warnings = list(dict.fromkeys(model_warnings))
+    if selected != included:
+        warnings.append("Included upstream dependencies required to make the offloaded Comfy graph runnable")
+    if (visual_region_selection or region_selection) and not explicit_selection:
+        warnings.append("Using Civitai Offload Start/End markers to select the submitted graph")
+
+    custom_input = {"resources": sorted(resources), "workflow": rewritten}
+    return OffloadBuildResult(
+        steps=[{"$type": "customComfy", "input": custom_input}],
+        workflow=rewritten,
+        resources=sorted(resources),
+        warnings=warnings,
+        selected_node_ids=sorted(selected, key=_node_sort_key),
+        included_node_ids=sorted(included, key=_node_sort_key),
+        model_resources=resolved_models,
+        nodepack_resources=nodepack_resources,
+    )

--- a/civitai_comfy_nodes/server_routes.py
+++ b/civitai_comfy_nodes/server_routes.py
@@ -4,10 +4,13 @@ No-op when imported outside ComfyUI (e.g. pytest)."""
 
 import asyncio
 import os
+import time
 import uuid
 
+import requests
+
 from . import catalog
-from .errors import CivitaiAuthError
+from .errors import CivitaiAuthError, CivitaiNodeError
 
 try:
     from aiohttp import web
@@ -153,6 +156,119 @@ def _import_blob(blob_id: str | None, url: str | None, kind: str) -> dict:
     return {"name": name, "subfolder": "", "type": "input"}
 
 
+def _download_url_to_input(url: str, kind: str = "image") -> dict:
+    import folder_paths  # ComfyUI runtime
+
+    response = requests.get(url, timeout=300)
+    if response.status_code >= 400:
+        raise CivitaiNodeError(f"Asset download failed ({response.status_code})")
+    data = response.content
+    safe = uuid.uuid4().hex[:16]
+    name = f"civitai_offload_{safe}{_guess_ext(kind, data)}"
+    path = os.path.join(folder_paths.get_input_directory(), name)
+    with open(path, "wb") as handle:
+        handle.write(data)
+    return {"name": name, "subfolder": "", "type": "input"}
+
+
+def _workflow_asset_urls(workflow: dict) -> list[str]:
+    urls: list[str] = []
+    for step in workflow.get("steps") or []:
+        output = step.get("output") or {}
+        assets = output.get("assets")
+        if isinstance(assets, list):
+            for asset in assets:
+                if isinstance(asset, str) and asset:
+                    urls.append(asset)
+                elif isinstance(asset, dict):
+                    url = asset.get("url") or asset.get("previewUrl")
+                    if url:
+                        urls.append(url)
+        for blob, _key in _walk_blobs(output):
+            url = blob.get("url") or blob.get("previewUrl")
+            if url:
+                urls.append(url)
+    return list(dict.fromkeys(urls))
+
+
+def _poll_workflow_to_terminal(client, workflow: dict, timeout_minutes: float) -> dict:
+    workflow_id = workflow.get("id") or workflow.get("workflowId")
+    if not workflow_id:
+        return workflow
+    deadline = time.monotonic() + max(1.0, timeout_minutes) * 60
+    current = workflow
+    while str(current.get("status") or "").lower() not in {"succeeded", "failed", "expired", "canceled"}:
+        if time.monotonic() > deadline:
+            raise CivitaiNodeError(f"Civitai workflow {workflow_id} timed out")
+        current = client.get_workflow(workflow_id, wait=10)
+    return current
+
+
+def _queue_local_prompt(comfy_base_url: str, prompt: dict) -> dict:
+    response = requests.post(
+        f"{comfy_base_url.rstrip('/')}/prompt",
+        json={"prompt": prompt, "client_id": "civitai-offload-hybrid"},
+        timeout=30,
+    )
+    if response.status_code >= 400:
+        raise CivitaiNodeError(f"Local Comfy continuation queue failed ({response.status_code}): {response.text}")
+    return response.json()
+
+
+def _offload_inventory() -> dict:
+    from . import offload
+
+    return {
+        "models": [record.as_dict() for record in offload.scan_local_model_files()],
+        "nodepacks": [nodepack.as_dict() for nodepack in offload.scan_installed_nodepacks()],
+    }
+
+
+def _offload_run(
+    prompt: dict,
+    selected_node_ids: list[str] | None,
+    workflow: dict | None,
+    wait: int,
+    whatif: bool,
+    *,
+    wait_until_complete: bool = False,
+) -> dict:
+    from . import offload
+    from .client import OrchestrationClient
+    from .config import resolve_config
+
+    config = resolve_config(interactive=False)
+    build = offload.build_custom_comfy_offload(
+        prompt,
+        selected_node_ids=selected_node_ids,
+        workflow=workflow,
+        token=config.token,
+    )
+    client = OrchestrationClient(config)
+    workflow = client.submit_steps(build.steps, wait=wait, whatif=whatif)
+    if wait_until_complete and not whatif:
+        workflow = _poll_workflow_to_terminal(client, workflow, config.timeout_minutes)
+    return {"workflow": workflow, "offload": build.as_dict()}
+
+
+def _run_local_tail(prompt: dict, offload_result: dict, comfy_base_url: str) -> dict | None:
+    from . import offload
+
+    assets = _workflow_asset_urls(offload_result["workflow"])
+    if not assets:
+        raise CivitaiNodeError("Civitai workflow completed but returned no downloadable customComfy assets")
+    imported = _download_url_to_input(assets[0], kind="image")
+    continuation = offload.build_local_continuation_prompt(
+        prompt,
+        remote_node_ids=offload_result["offload"].get("included_node_ids") or [],
+        imported_image_name=imported["name"],
+    )
+    if continuation is None:
+        return {"imported": imported, "continuation": None, "queue": None}
+    queue = _queue_local_prompt(comfy_base_url, continuation.prompt)
+    return {"imported": imported, "continuation": continuation.as_dict(), "queue": queue}
+
+
 def node_ecosystem_map() -> dict:
     """Map each recipe node class -> its expected AIR ecosystem (for the picker's default filter)."""
     from . import NODE_CLASS_MAPPINGS  # noqa: PLC0415 - deferred to call time to avoid an import cycle
@@ -272,6 +388,61 @@ if _server is not None:
             result = await loop.run_in_executor(None, lambda: _import_blob(blob_id, url, kind))
         except CivitaiAuthError:
             return web.json_response({"error": "auth_required"}, status=401)
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=502)
+        return web.json_response(result)
+
+    @_server.routes.get("/civitai/offload/inventory")
+    async def _civitai_offload_inventory(request):
+        loop = asyncio.get_event_loop()
+        try:
+            data = await loop.run_in_executor(None, _offload_inventory)
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=502)
+        return web.json_response(data)
+
+    @_server.routes.post("/civitai/offload/run")
+    async def _civitai_offload_run(request):
+        body = await request.json()
+        prompt = body.get("prompt") or body.get("output")
+        if not isinstance(prompt, dict):
+            return web.json_response({"error": "prompt must be a ComfyUI API prompt object"}, status=400)
+        selected = body.get("selectedNodeIds") or body.get("selected_node_ids") or None
+        if selected is not None and not isinstance(selected, list):
+            return web.json_response({"error": "selectedNodeIds must be an array"}, status=400)
+        workflow = body.get("workflow")
+        if workflow is not None and not isinstance(workflow, dict):
+            return web.json_response({"error": "workflow must be a serialized ComfyUI workflow object"}, status=400)
+        try:
+            wait = max(0, min(int(body.get("wait", 0)), 60))
+        except (TypeError, ValueError):
+            wait = 0
+        whatif = bool(body.get("whatif", False))
+        run_local_tail = bool(body.get("runLocalTail", False))
+        comfy_base_url = f"{request.scheme}://{request.host}"
+        loop = asyncio.get_event_loop()
+        try:
+            selected_ids = [str(node_id) for node_id in selected] if selected else None
+            result = await loop.run_in_executor(
+                None,
+                lambda: _offload_run(
+                    prompt,
+                    selected_ids,
+                    workflow,
+                    wait,
+                    whatif,
+                    wait_until_complete=run_local_tail,
+                ),
+            )
+            if run_local_tail and not whatif:
+                result["local"] = await loop.run_in_executor(
+                    None,
+                    lambda: _run_local_tail(prompt, result, comfy_base_url),
+                )
+        except CivitaiAuthError:
+            return web.json_response({"error": "auth_required"}, status=401)
+        except CivitaiNodeError as e:
+            return web.json_response({"error": str(e)}, status=400)
         except Exception as e:
             return web.json_response({"error": str(e)}, status=502)
         return web.json_response(result)

--- a/example_workflows/anima_offload_invert_local.json
+++ b/example_workflows/anima_offload_invert_local.json
@@ -1,0 +1,294 @@
+{
+  "last_node_id": 100,
+  "last_link_id": 12,
+  "nodes": [
+    {
+      "id": 99,
+      "type": "CivitaiOffloadStart",
+      "pos": [-280, 360],
+      "size": [260, 86],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        { "name": "value", "type": "*", "link": null }
+      ],
+      "outputs": [
+        { "name": "value", "type": "*", "links": [12], "slot_index": 0 }
+      ],
+      "properties": { "Node name for S&R": "CivitaiOffloadStart" },
+      "widgets_values": ["anima"]
+    },
+    {
+      "id": 1,
+      "type": "CLIPLoader",
+      "pos": [80, 80],
+      "size": [360, 106],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        { "name": "clip_name", "type": "COMBO", "widget": { "name": "clip_name" }, "link": null },
+        { "name": "type", "type": "COMBO", "widget": { "name": "type" }, "link": null },
+        { "name": "device", "type": "COMBO", "widget": { "name": "device" }, "link": null }
+      ],
+      "outputs": [
+        { "name": "CLIP", "type": "CLIP", "links": [1, 2], "slot_index": 0 }
+      ],
+      "properties": { "Node name for S&R": "CLIPLoader" },
+      "widgets_values": [
+        "urn:air:qwen:text_encoders:huggingface:circlestone-labs/Anima@main/split_files/text_encoders/qwen_3_06b_base.safetensors",
+        "stable_diffusion",
+        "default"
+      ]
+    },
+    {
+      "id": 2,
+      "type": "UNETLoader",
+      "pos": [80, 260],
+      "size": [360, 82],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        { "name": "unet_name", "type": "COMBO", "widget": { "name": "unet_name" }, "link": null },
+        { "name": "weight_dtype", "type": "COMBO", "widget": { "name": "weight_dtype" }, "link": null }
+      ],
+      "outputs": [
+        { "name": "MODEL", "type": "MODEL", "links": [3], "slot_index": 0 }
+      ],
+      "properties": { "Node name for S&R": "UNETLoader" },
+      "widgets_values": ["urn:air:anima:checkpoint:civitai:2458426@2836417", "default"]
+    },
+    {
+      "id": 3,
+      "type": "VAELoader",
+      "pos": [80, 420],
+      "size": [360, 58],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        { "name": "vae_name", "type": "COMBO", "widget": { "name": "vae_name" }, "link": null }
+      ],
+      "outputs": [
+        { "name": "VAE", "type": "VAE", "links": [4], "slot_index": 0 }
+      ],
+      "properties": { "Node name for S&R": "VAELoader" },
+      "widgets_values": [
+        "urn:air:anima:vae:huggingface:circlestone-labs/Anima@main/split_files/vae/qwen_image_vae.safetensors"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "CLIPTextEncode",
+      "pos": [520, 40],
+      "size": [460, 170],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        { "name": "clip", "type": "CLIP", "link": 1 },
+        { "name": "text", "type": "STRING", "widget": { "name": "text" }, "link": null }
+      ],
+      "outputs": [
+        { "name": "CONDITIONING", "type": "CONDITIONING", "links": [5], "slot_index": 0 }
+      ],
+      "properties": { "Node name for S&R": "CLIPTextEncode" },
+      "widgets_values": [
+        "masterpiece, best quality, safe, anime key visual of a young adventurer on a glass skybridge above a neon city at sunset"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 5,
+      "type": "CLIPTextEncode",
+      "pos": [520, 260],
+      "size": [460, 170],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        { "name": "clip", "type": "CLIP", "link": 2 },
+        { "name": "text", "type": "STRING", "widget": { "name": "text" }, "link": null }
+      ],
+      "outputs": [
+        { "name": "CONDITIONING", "type": "CONDITIONING", "links": [6], "slot_index": 0 }
+      ],
+      "properties": { "Node name for S&R": "CLIPTextEncode" },
+      "widgets_values": ["worst quality, low quality, blurry, watermark, text"],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 6,
+      "type": "EmptyLatentImage",
+      "pos": [520, 520],
+      "size": [315, 106],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        { "name": "width", "type": "INT", "widget": { "name": "width" }, "link": null },
+        { "name": "height", "type": "INT", "widget": { "name": "height" }, "link": null },
+        { "name": "batch_size", "type": "INT", "widget": { "name": "batch_size" }, "link": null }
+      ],
+      "outputs": [
+        { "name": "LATENT", "type": "LATENT", "links": [7], "slot_index": 0 }
+      ],
+      "properties": { "Node name for S&R": "EmptyLatentImage" },
+      "widgets_values": [512, 512, 1]
+    },
+    {
+      "id": 7,
+      "type": "KSampler",
+      "pos": [1060, 220],
+      "size": [315, 262],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        { "name": "model", "type": "MODEL", "link": 3 },
+        { "name": "positive", "type": "CONDITIONING", "link": 5 },
+        { "name": "negative", "type": "CONDITIONING", "link": 6 },
+        { "name": "latent_image", "type": "LATENT", "link": 7 },
+        { "name": "seed", "type": "INT", "widget": { "name": "seed" }, "link": null },
+        { "name": "steps", "type": "INT", "widget": { "name": "steps" }, "link": null },
+        { "name": "cfg", "type": "FLOAT", "widget": { "name": "cfg" }, "link": null },
+        { "name": "sampler_name", "type": "COMBO", "widget": { "name": "sampler_name" }, "link": null },
+        { "name": "scheduler", "type": "COMBO", "widget": { "name": "scheduler" }, "link": null },
+        { "name": "denoise", "type": "FLOAT", "widget": { "name": "denoise" }, "link": null }
+      ],
+      "outputs": [
+        { "name": "LATENT", "type": "LATENT", "links": [8], "slot_index": 0 }
+      ],
+      "properties": { "Node name for S&R": "KSampler" },
+      "widgets_values": [424343, "fixed", 8, 4, "dpmpp_2m_sde_gpu", "simple", 1]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [1460, 260],
+      "size": [210, 46],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        { "name": "samples", "type": "LATENT", "link": 8 },
+        { "name": "vae", "type": "VAE", "link": 4 }
+      ],
+      "outputs": [
+        { "name": "IMAGE", "type": "IMAGE", "links": [9, 10], "slot_index": 0 }
+      ],
+      "properties": { "Node name for S&R": "VAEDecode" },
+      "widgets_values": []
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [1760, 220],
+      "size": [315, 58],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        { "name": "images", "type": "IMAGE", "link": 9 },
+        { "name": "filename_prefix", "type": "STRING", "widget": { "name": "filename_prefix" }, "link": null }
+      ],
+      "outputs": [],
+      "properties": { "Node name for S&R": "SaveImage" },
+      "widgets_values": ["civitai-offload-anima"]
+    },
+    {
+      "id": 100,
+      "type": "CivitaiOffloadEnd",
+      "pos": [2140, 360],
+      "size": [260, 86],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        { "name": "value", "type": "*", "link": 12 }
+      ],
+      "outputs": [
+        { "name": "value", "type": "*", "links": null, "slot_index": 0 }
+      ],
+      "properties": { "Node name for S&R": "CivitaiOffloadEnd" },
+      "widgets_values": ["anima"]
+    },
+    {
+      "id": 10,
+      "type": "ImageInvert",
+      "pos": [2520, 260],
+      "size": [210, 46],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        { "name": "image", "type": "IMAGE", "link": 10 }
+      ],
+      "outputs": [
+        { "name": "IMAGE", "type": "IMAGE", "links": [11], "slot_index": 0 }
+      ],
+      "properties": { "Node name for S&R": "ImageInvert" },
+      "widgets_values": []
+    },
+    {
+      "id": 11,
+      "type": "SaveImage",
+      "pos": [2820, 220],
+      "size": [315, 58],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        { "name": "images", "type": "IMAGE", "link": 11 },
+        { "name": "filename_prefix", "type": "STRING", "widget": { "name": "filename_prefix" }, "link": null }
+      ],
+      "outputs": [],
+      "properties": { "Node name for S&R": "SaveImage" },
+      "widgets_values": ["local-after-civitai-offload-invert"]
+    }
+  ],
+  "links": [
+    [1, 1, 0, 4, 0, "CLIP"],
+    [2, 1, 0, 5, 0, "CLIP"],
+    [3, 2, 0, 7, 0, "MODEL"],
+    [4, 3, 0, 8, 1, "VAE"],
+    [5, 4, 0, 7, 1, "CONDITIONING"],
+    [6, 5, 0, 7, 2, "CONDITIONING"],
+    [7, 6, 0, 7, 3, "LATENT"],
+    [8, 7, 0, 8, 0, "LATENT"],
+    [9, 8, 0, 9, 0, "IMAGE"],
+    [10, 8, 0, 10, 0, "IMAGE"],
+    [11, 10, 0, 11, 0, "IMAGE"],
+    [12, 99, 0, 100, 0, "*"]
+  ],
+  "groups": [
+    {
+      "id": 1,
+      "title": "Offloaded anima customComfy region",
+      "bounding": [45, 0, 2070, 680],
+      "color": "#3f789e",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 2,
+      "title": "Local Comfy tail after remote output is imported",
+      "bounding": [2480, 170, 690, 190],
+      "color": "#9e7b3f",
+      "font_size": 24,
+      "flags": {}
+    }
+  ],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.48,
+      "offset": [430, 250]
+    }
+  },
+  "version": 0.4
+}

--- a/example_workflows/civitai_offload_marker_region.json
+++ b/example_workflows/civitai_offload_marker_region.json
@@ -1,0 +1,158 @@
+{
+  "last_node_id": 11,
+  "last_link_id": 4,
+  "nodes": [
+    {
+      "id": 10,
+      "type": "CivitaiOffloadStart",
+      "pos": [40, 120],
+      "size": [260, 86],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        { "name": "value", "type": "*", "link": null }
+      ],
+      "outputs": [
+        { "name": "value", "type": "*", "links": null, "slot_index": 0 }
+      ],
+      "properties": { "Node name for S&R": "CivitaiOffloadStart" },
+      "widgets_values": ["demo"]
+    },
+    {
+      "id": 1,
+      "type": "EmptyImage",
+      "pos": [340, 120],
+      "size": [315, 106],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        { "name": "width", "type": "INT", "widget": { "name": "width" }, "link": null },
+        { "name": "height", "type": "INT", "widget": { "name": "height" }, "link": null },
+        { "name": "batch_size", "type": "INT", "widget": { "name": "batch_size" }, "link": null },
+        { "name": "color", "type": "INT", "widget": { "name": "color" }, "link": null }
+      ],
+      "outputs": [
+        { "name": "IMAGE", "type": "IMAGE", "links": [1], "slot_index": 0 }
+      ],
+      "properties": { "Node name for S&R": "EmptyImage" },
+      "widgets_values": [512, 512, 1, 8421504]
+    },
+    {
+      "id": 2,
+      "type": "ImageInvert",
+      "pos": [700, 120],
+      "size": [210, 46],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        { "name": "image", "type": "IMAGE", "link": 1 }
+      ],
+      "outputs": [
+        { "name": "IMAGE", "type": "IMAGE", "links": [2, 3], "slot_index": 0 }
+      ],
+      "properties": { "Node name for S&R": "ImageInvert" },
+      "widgets_values": []
+    },
+    {
+      "id": 3,
+      "type": "SaveImage",
+      "pos": [980, 90],
+      "size": [315, 58],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        { "name": "images", "type": "IMAGE", "link": 2 },
+        { "name": "filename_prefix", "type": "STRING", "widget": { "name": "filename_prefix" }, "link": null }
+      ],
+      "outputs": [],
+      "properties": { "Node name for S&R": "SaveImage" },
+      "widgets_values": ["civitai-offload-remote"]
+    },
+    {
+      "id": 11,
+      "type": "CivitaiOffloadEnd",
+      "pos": [1340, 120],
+      "size": [260, 86],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        { "name": "value", "type": "*", "link": null }
+      ],
+      "outputs": [
+        { "name": "value", "type": "*", "links": null, "slot_index": 0 }
+      ],
+      "properties": { "Node name for S&R": "CivitaiOffloadEnd" },
+      "widgets_values": ["demo"]
+    },
+    {
+      "id": 4,
+      "type": "ImageInvert",
+      "pos": [1700, 120],
+      "size": [210, 46],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        { "name": "image", "type": "IMAGE", "link": 3 }
+      ],
+      "outputs": [
+        { "name": "IMAGE", "type": "IMAGE", "links": [4], "slot_index": 0 }
+      ],
+      "properties": { "Node name for S&R": "ImageInvert" },
+      "widgets_values": []
+    },
+    {
+      "id": 5,
+      "type": "SaveImage",
+      "pos": [1980, 90],
+      "size": [315, 58],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        { "name": "images", "type": "IMAGE", "link": 4 },
+        { "name": "filename_prefix", "type": "STRING", "widget": { "name": "filename_prefix" }, "link": null }
+      ],
+      "outputs": [],
+      "properties": { "Node name for S&R": "SaveImage" },
+      "widgets_values": ["local-after-offload-boundary"]
+    }
+  ],
+  "links": [
+    [1, 1, 0, 2, 0, "IMAGE"],
+    [2, 2, 0, 3, 0, "IMAGE"],
+    [3, 2, 0, 4, 0, "IMAGE"],
+    [4, 4, 0, 5, 0, "IMAGE"]
+  ],
+  "groups": [
+    {
+      "id": 1,
+      "title": "Offloaded by Run in Civitai",
+      "bounding": [315, 25, 1010, 260],
+      "color": "#3f789e",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 2,
+      "title": "Local tail after End is not submitted",
+      "bounding": [1660, 25, 670, 260],
+      "color": "#9e7b3f",
+      "font_size": 24,
+      "flags": {}
+    }
+  ],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.8,
+      "offset": [40, 160]
+    }
+  },
+  "version": 0.4
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,7 +15,7 @@ def _client(monkeypatch):
     captured = {}
 
     def fake_request(method, url, **kwargs):
-        captured.update(method=method, url=url, params=kwargs.get("params"))
+        captured.update(method=method, url=url, params=kwargs.get("params"), json=kwargs.get("json"))
         return _Resp()
 
     monkeypatch.setattr(client.session, "request", fake_request)
@@ -49,3 +49,15 @@ def test_query_workflows_can_request_mature(monkeypatch):
     client, captured = _client(monkeypatch)
     client.query_workflows(hide_mature=False)
     assert captured["params"]["hideMatureContent"] == "false"
+
+
+def test_submit_steps_posts_workflow_body(monkeypatch):
+    client, captured = _client(monkeypatch)
+    steps = [{"$type": "customComfy", "input": {"resources": ["urn:air:x"], "workflow": {"1": {}}}}]
+
+    client.submit_steps(steps, wait=0, whatif=True)
+
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("/v2/consumer/workflows")
+    assert captured["params"] == {"wait": 0, "whatif": "true"}
+    assert captured["json"] == {"steps": steps}

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -1,0 +1,339 @@
+import hashlib
+import json
+import sys
+import types
+
+from civitai_comfy_nodes import offload
+
+
+def _write_safetensors(path, header, payload=b"tensor-bytes"):
+    header_bytes = json.dumps(header).encode("utf-8")
+    path.write_bytes(len(header_bytes).to_bytes(8, "little") + header_bytes + payload)
+
+
+def test_reads_safetensors_metadata_hash_before_computing(tmp_path):
+    model = tmp_path / "model.safetensors"
+    embedded = "a" * 64
+    _write_safetensors(model, {"__metadata__": {"sshs_model_hash": embedded}})
+
+    hashes, source = offload.get_model_hashes(model)
+
+    assert source == "metadata"
+    assert hashes == {"AutoV3": embedded.upper()}
+
+
+def test_compute_model_hashes_matches_scanner_shape(tmp_path):
+    model = tmp_path / "tiny.bin"
+    model.write_bytes(b"hello world")
+
+    hashes = offload.compute_model_hashes(model)
+
+    sha = hashlib.sha256(b"hello world").hexdigest().upper()
+    assert hashes["SHA256"] == sha
+    assert hashes["AutoV2"] == sha[:10]
+    assert hashes["CRC32"] == "0D4A1185"
+    assert "AutoV1" not in hashes
+
+
+def test_compute_autov3_for_safetensors_payload(tmp_path):
+    model = tmp_path / "model.safetensors"
+    payload = b"payload-only"
+    _write_safetensors(model, {"__metadata__": {"format": "pt"}}, payload=payload)
+
+    hashes = offload.compute_model_hashes(model)
+
+    assert hashes["AutoV3"] == hashlib.sha256(payload).hexdigest().upper()
+
+
+class _Resp:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _Session:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.urls = []
+
+    def get(self, url, **kwargs):
+        self.urls.append(url)
+        return self.responses.pop(0)
+
+
+def test_resolve_model_air_uses_metadata_then_computed_fallback(tmp_path):
+    model = tmp_path / "model.safetensors"
+    _write_safetensors(model, {"__metadata__": {"sshs_model_hash": "b" * 64}}, payload=b"payload")
+    session = _Session(
+        [
+            _Resp(404, {"error": "not found"}),
+            _Resp(200, {"id": 12, "air": "urn:air:sdxl:checkpoint:civitai:1@12"}),
+        ]
+    )
+
+    resolved = offload.resolve_model_air(model, session=session, civitai_base_url="http://civitai.test")
+
+    assert resolved.air == "urn:air:sdxl:checkpoint:civitai:1@12"
+    assert resolved.hash_source == "computed"
+    assert session.urls[0].endswith("/" + "B" * 64)
+    assert session.urls[1].endswith("/" + hashlib.sha256(model.read_bytes()).hexdigest().upper())
+
+
+def test_scan_installed_nodepacks_infers_air_only_with_version(tmp_path):
+    rgthree = tmp_path / "rgthree-comfy"
+    rgthree.mkdir()
+    (rgthree / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "rgthree-comfy",
+                "version": "1.0.2605082257",
+                "repository": {"url": "https://github.com/rgthree/rgthree-comfy.git"},
+            }
+        )
+    )
+    commit_only = tmp_path / "commit-only"
+    commit_only.mkdir()
+    (commit_only / "package.json").write_text(
+        json.dumps({"name": "commit-only", "repository": "https://github.com/acme/commit-only"})
+    )
+
+    nodepacks = {nodepack.folder: nodepack for nodepack in offload.scan_installed_nodepacks(tmp_path)}
+
+    assert nodepacks["rgthree-comfy"].air == (
+        "urn:air:comfy:nodepack:comfyregistry:rgthree/rgthree-comfy@1.0.2605082257"
+    )
+    assert nodepacks["commit-only"].version is None
+    assert nodepacks["commit-only"].air is None
+
+
+def test_build_custom_comfy_offload_rewrites_local_models_and_adds_nodepacks(tmp_path):
+    prompt = {
+        "1": {"class_type": "CheckpointLoaderSimple", "inputs": {"ckpt_name": "dream.safetensors"}},
+        "2": {"class_type": "SaveImage", "inputs": {"images": ["1", 0]}},
+    }
+    model = offload.LocalModelRecord(
+        folder="checkpoints",
+        name="dream.safetensors",
+        path=str(tmp_path / "dream.safetensors"),
+        air="urn:air:sdxl:checkpoint:civitai:11@22",
+    )
+    nodepack = offload.InstalledNodepack(
+        folder="rgthree-comfy",
+        registry_id="rgthree/rgthree-comfy",
+        version="1.0.0",
+        air="urn:air:comfy:nodepack:comfyregistry:rgthree/rgthree-comfy@1.0.0",
+    )
+
+    built = offload.build_custom_comfy_offload(prompt, model_records=[model], nodepacks=[nodepack])
+
+    custom_input = built.steps[0]["input"]
+    assert built.steps[0]["$type"] == "customComfy"
+    assert custom_input["workflow"]["1"]["inputs"]["ckpt_name"] == "urn:air:sdxl:checkpoint:civitai:11@22"
+    assert custom_input["resources"] == [
+        "urn:air:comfy:nodepack:comfyregistry:rgthree/rgthree-comfy@1.0.0",
+        "urn:air:sdxl:checkpoint:civitai:11@22",
+    ]
+
+
+def test_build_custom_comfy_offload_only_adds_used_nodepacks(monkeypatch):
+    class UsedNode:
+        RELATIVE_PYTHON_MODULE = "custom_nodes.rgthree-comfy.nodes"
+
+    class UnusedNode:
+        RELATIVE_PYTHON_MODULE = "custom_nodes.other-pack.nodes"
+
+    monkeypatch.setitem(
+        sys.modules,
+        "nodes",
+        types.SimpleNamespace(
+            NODE_CLASS_MAPPINGS={
+                "UsedCustomNode": UsedNode,
+                "UnusedCustomNode": UnusedNode,
+                "SaveImage": type("SaveImage", (), {"RELATIVE_PYTHON_MODULE": "nodes"}),
+            }
+        ),
+    )
+    prompt = {
+        "1": {"class_type": "UsedCustomNode", "inputs": {}},
+        "2": {"class_type": "SaveImage", "inputs": {"images": ["1", 0]}},
+    }
+    nodepacks = [
+        offload.InstalledNodepack(
+            folder="rgthree-comfy",
+            registry_id="rgthree/rgthree-comfy",
+            version="1.0.0",
+            air="urn:air:comfy:nodepack:comfyregistry:rgthree/rgthree-comfy@1.0.0",
+        ),
+        offload.InstalledNodepack(
+            folder="other-pack",
+            registry_id="acme/other-pack",
+            version="2.0.0",
+            air="urn:air:comfy:nodepack:comfyregistry:acme/other-pack@2.0.0",
+        ),
+    ]
+
+    built = offload.build_custom_comfy_offload(prompt, model_records=[], nodepacks=nodepacks)
+
+    assert built.steps[0]["input"]["resources"] == [
+        "urn:air:comfy:nodepack:comfyregistry:rgthree/rgthree-comfy@1.0.0"
+    ]
+    assert [nodepack["folder"] for nodepack in built.nodepack_resources] == ["rgthree-comfy"]
+
+
+def test_offload_markers_select_region_and_are_stripped():
+    prompt = {
+        "1": {"class_type": "EmptyImage", "inputs": {"width": 64, "height": 64, "batch_size": 1}},
+        "2": {"class_type": "CivitaiOffloadStart", "inputs": {"region_id": "r", "value": ["1", 0]}},
+        "3": {"class_type": "PreviewImage", "inputs": {"images": ["2", 0]}},
+        "4": {"class_type": "CivitaiOffloadEnd", "inputs": {"region_id": "r", "value": ["3", 0]}},
+        "5": {"class_type": "SaveImage", "inputs": {"images": ["4", 0]}},
+    }
+
+    built = offload.build_custom_comfy_offload(prompt, model_records=[], nodepacks=[])
+
+    assert "2" not in built.workflow
+    assert "4" not in built.workflow
+    assert built.workflow["3"]["inputs"]["images"] == ["1", 0]
+    assert built.selected_node_ids == ["2", "3", "4"]
+    assert built.included_node_ids == ["1", "2", "3", "4"]
+
+
+def test_offload_markers_preserve_user_save_inside_region_and_exclude_local_tail():
+    prompt = {
+        "1": {"class_type": "VAEDecode", "inputs": {"samples": ["100", 0], "vae": ["101", 0]}},
+        "2": {"class_type": "CivitaiOffloadStart", "inputs": {"region_id": "anima", "value": ["1", 0]}},
+        "3": {"class_type": "SaveImage", "inputs": {"filename_prefix": "civitai-offload-anima", "images": ["2", 0]}},
+        "4": {"class_type": "CivitaiOffloadEnd", "inputs": {"region_id": "anima", "value": ["2", 0]}},
+        "5": {"class_type": "LoadImage", "inputs": {"image": "civitai_offload_marker_remote.png"}},
+        "6": {"class_type": "ImageInvert", "inputs": {"image": ["5", 0]}},
+        "7": {"class_type": "SaveImage", "inputs": {"filename_prefix": "local-after-offload", "images": ["6", 0]}},
+        "100": {"class_type": "KSampler", "inputs": {}},
+        "101": {"class_type": "VAELoader", "inputs": {}},
+    }
+
+    built = offload.build_custom_comfy_offload(prompt, model_records=[], nodepacks=[])
+
+    assert "2" not in built.workflow
+    assert "4" not in built.workflow
+    assert "5" not in built.workflow
+    assert "6" not in built.workflow
+    assert "7" not in built.workflow
+    assert built.workflow["3"] == {
+        "class_type": "SaveImage",
+        "inputs": {"filename_prefix": "civitai-offload-anima", "images": ["1", 0]},
+    }
+
+
+def test_visual_offload_markers_select_nodes_between_start_and_end_with_save_image():
+    prompt = {
+        "1": {"class_type": "EmptyImage", "inputs": {"width": 64, "height": 64, "batch_size": 1}},
+        "2": {"class_type": "ImageInvert", "inputs": {"image": ["1", 0]}},
+        "3": {"class_type": "SaveImage", "inputs": {"filename_prefix": "remote", "images": ["2", 0]}},
+        "4": {"class_type": "ImageBlur", "inputs": {"image": ["2", 0], "blur_radius": 2, "sigma": 1.0}},
+        "5": {"class_type": "SaveImage", "inputs": {"filename_prefix": "local", "images": ["4", 0]}},
+    }
+    workflow = {
+        "nodes": [
+            {"id": 100, "type": "CivitaiOffloadStart", "pos": [0, 0], "widgets_values": ["anima"]},
+            {"id": 1, "type": "EmptyImage", "pos": [120, -120]},
+            {"id": 2, "type": "ImageInvert", "pos": [280, -120]},
+            {"id": 3, "type": "SaveImage", "pos": [440, -120]},
+            {"id": 101, "type": "CivitaiOffloadEnd", "pos": [620, 0], "widgets_values": ["anima"]},
+            {"id": 4, "type": "ImageBlur", "pos": [760, -120]},
+            {"id": 5, "type": "SaveImage", "pos": [920, -120]},
+        ]
+    }
+
+    built = offload.build_custom_comfy_offload(prompt, workflow=workflow, model_records=[], nodepacks=[])
+
+    assert built.selected_node_ids == ["1", "2", "3"]
+    assert built.included_node_ids == ["1", "2", "3"]
+    assert set(built.workflow) == {"1", "2", "3"}
+    assert built.workflow["3"] == {
+        "class_type": "SaveImage",
+        "inputs": {"filename_prefix": "remote", "images": ["2", 0]},
+    }
+
+
+def test_explicit_selection_overrides_visual_offload_markers():
+    prompt = {
+        "1": {"class_type": "EmptyImage", "inputs": {"width": 64, "height": 64, "batch_size": 1}},
+        "2": {"class_type": "SaveImage", "inputs": {"filename_prefix": "remote", "images": ["1", 0]}},
+        "3": {"class_type": "SaveImage", "inputs": {"filename_prefix": "manual", "images": ["1", 0]}},
+    }
+    workflow = {
+        "nodes": [
+            {"id": 100, "type": "CivitaiOffloadStart", "pos": [0, 0], "widgets_values": ["default"]},
+            {"id": 1, "type": "EmptyImage", "pos": [120, 0]},
+            {"id": 2, "type": "SaveImage", "pos": [280, 0]},
+            {"id": 101, "type": "CivitaiOffloadEnd", "pos": [440, 0], "widgets_values": ["default"]},
+            {"id": 3, "type": "SaveImage", "pos": [600, 0]},
+        ]
+    }
+
+    built = offload.build_custom_comfy_offload(
+        prompt,
+        selected_node_ids=["3"],
+        workflow=workflow,
+        model_records=[],
+        nodepacks=[],
+    )
+
+    assert built.selected_node_ids == ["3"]
+    assert built.included_node_ids == ["1", "3"]
+    assert set(built.workflow) == {"1", "3"}
+
+
+def test_build_local_continuation_replaces_remote_region_with_load_image_bridge():
+    prompt = {
+        "1": {"class_type": "CLIPLoader", "inputs": {"clip_name": "clip.safetensors"}},
+        "2": {"class_type": "UNETLoader", "inputs": {"unet_name": "anima.safetensors"}},
+        "3": {"class_type": "VAELoader", "inputs": {"vae_name": "vae.safetensors"}},
+        "4": {"class_type": "CLIPTextEncode", "inputs": {"clip": ["1", 0], "text": "prompt"}},
+        "5": {"class_type": "EmptyLatentImage", "inputs": {"width": 64, "height": 64, "batch_size": 1}},
+        "6": {
+            "class_type": "KSampler",
+            "inputs": {"model": ["2", 0], "positive": ["4", 0], "negative": ["4", 0], "latent_image": ["5", 0]},
+        },
+        "7": {"class_type": "VAEDecode", "inputs": {"samples": ["6", 0], "vae": ["3", 0]}},
+        "8": {"class_type": "SaveImage", "inputs": {"filename_prefix": "remote", "images": ["7", 0]}},
+        "9": {"class_type": "ImageInvert", "inputs": {"image": ["7", 0]}},
+        "10": {"class_type": "SaveImage", "inputs": {"filename_prefix": "local", "images": ["9", 0]}},
+    }
+
+    built = offload.build_local_continuation_prompt(
+        prompt,
+        remote_node_ids=["1", "2", "3", "4", "5", "6", "7", "8"],
+        imported_image_name="civitai_offload_remote.png",
+    )
+
+    assert built is not None
+    assert built.bridge_node_id == "civitai_remote_asset"
+    assert built.tail_node_ids == ["9", "10"]
+    assert built.output_node_ids == ["10"]
+    assert built.remote_source_node_ids == ["7"]
+    assert built.prompt == {
+        "civitai_remote_asset": {"class_type": "LoadImage", "inputs": {"image": "civitai_offload_remote.png"}},
+        "9": {"class_type": "ImageInvert", "inputs": {"image": ["civitai_remote_asset", 0]}},
+        "10": {"class_type": "SaveImage", "inputs": {"filename_prefix": "local", "images": ["9", 0]}},
+    }
+
+
+def test_build_local_continuation_returns_none_when_no_local_tail():
+    prompt = {
+        "1": {"class_type": "EmptyImage", "inputs": {"width": 64, "height": 64, "batch_size": 1}},
+        "2": {"class_type": "SaveImage", "inputs": {"images": ["1", 0]}},
+    }
+
+    assert (
+        offload.build_local_continuation_prompt(
+            prompt,
+            remote_node_ids=["1", "2"],
+            imported_image_name="civitai_offload_remote.png",
+        )
+        is None
+    )

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -84,3 +84,23 @@ def test_guess_ext_sniffs_magic_bytes():
     assert sr._guess_ext("image", b"\xff\xd8\xff\xe0\x00\x10JFIF") == ".jpg"
     assert sr._guess_ext("video", b"\x00\x00\x00\x18ftypmp42") == ".mp4"
     assert sr._guess_ext("audio", b"not a known header") == ".flac"  # falls back by kind
+
+
+def test_workflow_asset_urls_reads_custom_comfy_assets_and_blobs():
+    workflow = _wf(
+        [
+            {
+                "$type": "customComfy",
+                "output": {
+                    "assets": ["http://asset/a.png", {"url": "http://asset/b.png"}],
+                    "images": [{"id": "blob1", "available": True, "url": "http://blob/c.png"}],
+                },
+            }
+        ]
+    )
+
+    assert sr._workflow_asset_urls(workflow) == [
+        "http://asset/a.png",
+        "http://asset/b.png",
+        "http://blob/c.png",
+    ]

--- a/web/civitai-offload.js
+++ b/web/civitai-offload.js
@@ -1,0 +1,178 @@
+// Adds a "Run in Civitai" action that sends the current ComfyUI API prompt to the pack's
+// /civitai/offload/run route. The backend handles OAuth, local model AIR lookup, and nodepack AIRs.
+import { app } from "../../scripts/app.js";
+
+let stylesInjected = false;
+
+function injectStyles() {
+  if (stylesInjected) return;
+  stylesInjected = true;
+  const style = document.createElement("style");
+  style.textContent = `
+    .cvo-run {
+      border: 1px solid var(--border-color, #3f3f46);
+      background: var(--comfy-input-bg, #27272a);
+      color: var(--input-text, #e4e4e7);
+      border-radius: 6px;
+      padding: 6px 10px;
+      font: inherit;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .cvo-run:hover { border-color: #2563eb; }
+    .cvo-run[disabled] { opacity: .6; cursor: progress; }
+    .cvo-run-inline { height: 32px; margin-left: 6px; }
+    .cvo-run-menu {
+      width: 100%;
+      text-align: left;
+    }
+    .cvo-run-menu[disabled] { opacity: .6; cursor: progress; }
+  `;
+  document.head.appendChild(style);
+}
+
+function toast(severity, summary, detail) {
+  try {
+    app.extensionManager.toast.add({ severity, summary, detail, life: 5000 });
+  } catch (e) {
+    console[severity === "error" ? "error" : "log"](`[civitai-offload] ${summary}: ${detail ?? ""}`);
+  }
+}
+
+function selectedNodeIds() {
+  return Object.values(app.canvas?.selected_nodes || {}).map((node) => String(node.id));
+}
+
+async function currentPrompt() {
+  if (!app.graphToPrompt) throw new Error("This ComfyUI frontend does not expose graphToPrompt()");
+  const graph = await app.graphToPrompt();
+  const prompt = graph?.output || graph?.prompt || graph;
+  if (!prompt || typeof prompt !== "object") throw new Error("Could not serialize the current workflow as an API prompt");
+  return { prompt, workflow: graph?.workflow || app.graph?.serialize?.() };
+}
+
+async function runInCivitai(button) {
+  button.disabled = true;
+  const oldText = button.textContent;
+  button.textContent = "Submitting...";
+  try {
+    const payload = await currentPrompt();
+    payload.selectedNodeIds = selectedNodeIds();
+    payload.wait = 5;
+    payload.runLocalTail = true;
+    const res = await fetch("/civitai/offload/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    const data = await res.json();
+    if (res.status === 401 || data.error === "auth_required") {
+      throw new Error("Connect Civitai OAuth or save an API key first");
+    }
+    if (!res.ok || data.error) throw new Error(data.error || `request failed (${res.status})`);
+    const id = data.workflow?.id || data.workflow?.workflowId || "submitted";
+    const local = data.local?.queue?.prompt_id ? ` Local continuation ${data.local.queue.prompt_id} queued.` : "";
+    const warnings = data.offload?.warnings?.length ? ` ${data.offload.warnings.join(" ")}` : "";
+    toast("success", "Submitted to Civitai", `${id}.${local}${warnings}`);
+  } catch (e) {
+    toast("error", "Civitai offload failed", String(e.message || e));
+  } finally {
+    button.disabled = false;
+    button.textContent = oldText;
+  }
+}
+
+function findQueueButton() {
+  const byId = document.querySelector(
+    '#queue-button, .comfyui-button-queue, [data-testid="queue-button"]'
+  );
+  if (byId) return byId;
+  const buttons = [...document.querySelectorAll("button")];
+  return buttons.find((button) => /queue|run/i.test(button.textContent || ""));
+}
+
+function installRunButton() {
+  if (document.querySelector(".cvo-run-inline")) return true;
+  const queue = findQueueButton();
+  if (!queue || !queue.parentElement) return false;
+  const button = document.createElement("button");
+  button.className = "cvo-run cvo-run-inline";
+  button.type = "button";
+  button.title = "Submit this workflow through Civitai customComfy offload";
+  button.textContent = "Run in Civitai";
+  button.addEventListener("click", () => runInCivitai(button));
+  const group = queue.closest(".queue-button-group") || queue.parentElement;
+  group.insertAdjacentElement("afterend", button);
+  return true;
+}
+
+function normalizedText(el) {
+  return (el.textContent || "").replace(/\s+/g, " ").trim();
+}
+
+function findOpenRunMenu() {
+  const runModeButtons = [...document.querySelectorAll("button")].filter((button) => {
+    const text = normalizedText(button);
+    return text === "Run" || text === "Run (On Change)" || text === "Run (Instant)";
+  });
+  for (const button of runModeButtons) {
+    let el = button.parentElement;
+    while (el && el !== document.body) {
+      const texts = [...el.querySelectorAll("button")].map(normalizedText);
+      if (texts.includes("Run") && texts.some((text) => text === "Run (On Change)" || text === "Run (Instant)")) {
+        return el;
+      }
+      el = el.parentElement;
+    }
+  }
+  return null;
+}
+
+function installDropdownItem() {
+  const menu = findOpenRunMenu();
+  if (!menu || menu.querySelector(".cvo-run-menu")) return false;
+  const reference =
+    [...menu.querySelectorAll("button")].find((item) => normalizedText(item) === "Run (Instant)") ||
+    menu.querySelector("button");
+  const button = document.createElement("button");
+  button.className = reference?.className || "cvo-run-menu";
+  button.classList.add("cvo-run-menu");
+  button.type = "button";
+  button.textContent = "Run in Civitai";
+  button.title = "Submit this workflow through Civitai customComfy offload";
+  if (reference) {
+    const style = window.getComputedStyle(reference);
+    button.style.fontFamily = style.fontFamily;
+    button.style.fontSize = style.fontSize;
+    button.style.fontWeight = style.fontWeight;
+    button.style.lineHeight = style.lineHeight;
+    button.style.padding = style.padding;
+    button.style.minHeight = style.minHeight;
+  }
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    runInCivitai(button);
+  });
+  menu.appendChild(button);
+  return true;
+}
+
+app.registerExtension({
+  name: "civitai.offload",
+  async setup() {
+    injectStyles();
+    let tries = 0;
+    const timer = setInterval(() => {
+      tries += 1;
+      if (installRunButton() || tries > 40) clearInterval(timer);
+    }, 500);
+    const observer = new MutationObserver(() => installDropdownItem());
+    observer.observe(document.body, { childList: true, subtree: true });
+    document.addEventListener("click", () => setTimeout(installDropdownItem, 0), true);
+  },
+  nodeCreated(node) {
+    if (node.comfyClass === "CivitaiOffloadStart") node.color = "#1d4ed8";
+    if (node.comfyClass === "CivitaiOffloadEnd") node.color = "#0f766e";
+  },
+});


### PR DESCRIPTION
Adds Run in Civitai offload support for marker-delimited custom Comfy workflows. The node pack resolves local models and installed node packs to AIR resources, submits the selected region as customComfy, imports the returned asset, and queues the downstream local continuation. Includes example workflows and tests for the transform and route helpers.