### PR TITLE
build(publish): exclude dev/build files from the Comfy Registry package

### DIFF
--- a/.comfyignore
+++ b/.comfyignore
@@ -1,0 +1,13 @@
+# Build tooling
+codegen/
+spec/
+
+# Tests, dev scripts, CI, and agent/dev docs.
+tests/
+scripts/
+.github/
+CLAUDE.md
+
+# Repo meta — irrelevant once published.
+.gitignore
+.comfyignore


### PR DESCRIPTION
## What
Adds a `.comfyignore` so the published Comfy Registry package contains only
runtime files: `civitai_comfy_nodes/`, `web/`, `example_workflows/`, and the
registry metadata (`pyproject.toml` / `README.md` / `requirements.txt`).

Excluded: `codegen/`, `spec/`, `tests/`, `scripts/`, `.github/`, `CLAUDE.md`,
and the repo-meta dotfiles.

## Why
`comfy-cli node publish` zips **git-tracked files minus `.comfyignore`**
(`file_utils.py:zip_files`). Today that means every installer downloads the
build tooling and an 877K API spec dump they never use — ~1.8M of source vs.
~780K of actual runtime. The spec alone is larger than the whole node.

## Safety
The spec is a *build-time* input, baked into the generated `FIELDS`/`OUTPUTS`
tables at codegen time. Verified:
- no runtime `import codegen`/`ir`/`emit`;
- no runtime file open touches `spec/` (the only `v2-consumers.json` mentions
  are generated header comments);
- importing the package with `spec/` and `codegen/` physically removed
  registers all 161 node classes.

`.gitignore`'d paths are intentionally **not** listed — the publish zip is
git-tracked-only, so they're already excluded.

## Reference
https://docs.comfy.org/registry/publishing#exclude-files-with-comfyignore