### PR TITLE
Enhance Civitai model selector with per-prompt credentials and component outputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ converts blob outputs to native Comfy types.
   → `CIVITAI_CONTROLNETS`. `base._build_payload` serializes each (AIR string, AIR list, lora
   array/AIR-keyed map, controlnet array). `field_types: {field: "air"}` forces an AIR-by-description
   field that lacks the pattern (e.g. `imageUpscaler.model`). `CivitaiModelSelector` outputs the
-  `air` (`CIVITAI_AIR`) plus `path`/`vae`/`clip`/`clip 2`/`clip 3` (all `*`/AnyType — wire into a
+  `air` (`CIVITAI_AIR`) plus `path`/`clip`/`vae`/`clip 2`/`clip 3` (all `*`/AnyType — wire into a
   standard loader's file combo); `path` is the version's primary file, the rest are its additional
   components (`catalog.components` groups the version `files[]` by Civitai `type`: VAE → `vae`,
   Text Encoder → `clip` in API order). Each output downloads into the matching ComfyUI folder only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,11 +19,12 @@ converts blob outputs to native Comfy types.
   field that lacks the pattern (e.g. `imageUpscaler.model`). `CivitaiModelSelector` outputs the
   `air` (`CIVITAI_AIR`) plus `path`/`clip`/`vae`/`clip 2`/`clip 3` (all `*`/AnyType — wire into a
   standard loader's file combo); `path` is the version's primary file, the rest are its additional
-  components (`catalog.components` groups the version `files[]` by Civitai `type`: VAE → `vae`,
-  Text Encoder → `clip` in API order). Each output downloads into the matching ComfyUI folder only
-  when wired (PROMPT/UNIQUE_ID `_consumed_slots` + `IS_CHANGED`); component files key on their file
-  id (`local_models.download_model(download_url=…, file_id=…)`) so siblings sharing a folder don't
-  collide. The picker (`web/civitai-catalog.js` `applyComponentOutputs`) keeps the node's outputs a
+  components (`catalog.components` returns the `primary` file plus VAE → `vae` / Text Encoder →
+  `clip` buckets, in API order). Each output downloads only when wired (PROMPT/UNIQUE_ID
+  `_consumed_slots` + `IS_CHANGED`) into the folder for its *file's* Civitai `type` via
+  `local_models.folder_for_file_type` (so a Checkpoint model whose primary file is a Diffusion
+  Model lands in `diffusion_models/`, not `checkpoints/`); component files key on their file id
+  (`download_model(download_url=…, file_id=…)`) so siblings sharing a folder don't collide. The picker (`web/civitai-catalog.js` `applyComponentOutputs`) keeps the node's outputs a
   prefix of the canonical list and collapses/relabels the component slots to the selected model.
   The Browse-Civitai picker button is on the selector nodes only (NODE_TARGETS), never on recipe nodes.
 - `civitai_comfy_nodes/base.py` — all runtime behavior: payload building from `FIELDS`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,15 @@ converts blob outputs to native Comfy types.
   → `CIVITAI_CONTROLNETS`. `base._build_payload` serializes each (AIR string, AIR list, lora
   array/AIR-keyed map, controlnet array). `field_types: {field: "air"}` forces an AIR-by-description
   field that lacks the pattern (e.g. `imageUpscaler.model`). `CivitaiModelSelector` outputs the
-  `air` (`CIVITAI_AIR`) plus a `path` (`*`/AnyType — wires into any standard loader's file combo);
-  the model downloads into `local_models.folder_for_air(air)` only when `path` is wired (PROMPT/
-  UNIQUE_ID `_path_consumed` + `IS_CHANGED`). The Browse-Civitai picker button is on the selector
-  nodes only (`web/civitai-catalog.js` NODE_TARGETS), never on recipe nodes.
+  `air` (`CIVITAI_AIR`) plus `path`/`vae`/`clip`/`clip 2`/`clip 3` (all `*`/AnyType — wire into a
+  standard loader's file combo); `path` is the version's primary file, the rest are its additional
+  components (`catalog.components` groups the version `files[]` by Civitai `type`: VAE → `vae`,
+  Text Encoder → `clip` in API order). Each output downloads into the matching ComfyUI folder only
+  when wired (PROMPT/UNIQUE_ID `_consumed_slots` + `IS_CHANGED`); component files key on their file
+  id (`local_models.download_model(download_url=…, file_id=…)`) so siblings sharing a folder don't
+  collide. The picker (`web/civitai-catalog.js` `applyComponentOutputs`) keeps the node's outputs a
+  prefix of the canonical list and collapses/relabels the component slots to the selected model.
+  The Browse-Civitai picker button is on the selector nodes only (NODE_TARGETS), never on recipe nodes.
 - `civitai_comfy_nodes/base.py` — all runtime behavior: payload building from `FIELDS`,
   submit → poll loop (interrupt-aware, ProgressBar), output conversion per `OUTPUTS`. `run()`
   returns `{"ui": {"civitai_status": [...]}, "result": (...)}`; the `ui` payload (workflow id +

--- a/civitai_comfy_nodes/__init__.py
+++ b/civitai_comfy_nodes/__init__.py
@@ -1,4 +1,6 @@
-from . import generated, nodes_manual
+from . import generated, nodes_manual, prompt_context
+
+prompt_context.register()
 
 NODE_CLASS_MAPPINGS = {
     **generated.NODE_CLASS_MAPPINGS,

--- a/civitai_comfy_nodes/base.py
+++ b/civitai_comfy_nodes/base.py
@@ -11,7 +11,7 @@ import threading
 import time
 from dataclasses import dataclass
 
-from . import comfy_compat, conversions
+from . import comfy_compat, conversions, prompt_context
 from .client import TERMINAL_STATUSES, OrchestrationClient
 from .config import resolve_config, submit_tags
 from .errors import CivitaiNodeError, workflow_failure_message
@@ -91,7 +91,10 @@ class CivitaiRecipeNodeBase:
         missing = self._missing_required(widgets)
         if missing:
             raise CivitaiNodeError(self._missing_message(missing))
-        config = resolve_config(api_config)
+        # A hosted prompt carries its credentials in extra_data; never fall back
+        # to a browser login there — the container is headless.
+        interactive = prompt_context.current() is None
+        config = resolve_config(api_config, interactive=interactive)
         client = OrchestrationClient(config)
         payload = self._build_payload(client, widgets)
         payload.update(self.DISCRIMINATOR)

--- a/civitai_comfy_nodes/catalog.py
+++ b/civitai_comfy_nodes/catalog.py
@@ -272,40 +272,41 @@ _FILE_TYPE_BUCKETS = {
 
 
 def _parse_components(files: list | None) -> dict:
-    """Group a version's non-primary files into the selector's component buckets, preserving API
-    order so multiple text encoders map to clip / clip 2 / clip 3 deterministically. Each entry is
-    {id, name, downloadUrl, isRequired} — enough to label the output and download the file."""
-    buckets: dict[str, list] = {"vae": [], "clip": []}
+    """Classify a version's files for the Model Selector. `primary` is the main file (whatever its
+    type — the download folder follows it, not the AIR), and `vae`/`clip` are the non-primary files
+    that get component outputs, in API order so multiple text encoders map to clip / clip 2 / clip 3
+    deterministically. Each entry is {id, name, type, downloadUrl, isRequired}."""
+    result: dict = {"primary": None, "vae": [], "clip": []}
     for f in files or []:
+        entry = {
+            "id": f.get("id"),
+            "name": f.get("name") or "",
+            "type": (f.get("type") or "").strip(),
+            "downloadUrl": f.get("downloadUrl"),
+            "isRequired": bool((f.get("metadata") or {}).get("isRequired")),
+        }
         if f.get("primary"):
+            if result["primary"] is None:
+                result["primary"] = entry
             continue
-        bucket = _FILE_TYPE_BUCKETS.get((f.get("type") or "").strip())
-        download_url = f.get("downloadUrl")
-        file_id = f.get("id")
-        if not bucket or not download_url or file_id is None:
+        bucket = _FILE_TYPE_BUCKETS.get(entry["type"])
+        if not bucket or not entry["downloadUrl"] or entry["id"] is None:
             continue
-        buckets[bucket].append(
-            {
-                "id": file_id,
-                "name": f.get("name") or "",
-                "downloadUrl": download_url,
-                "isRequired": bool((f.get("metadata") or {}).get("isRequired")),
-            }
-        )
-    return buckets
+        result[bucket].append(entry)
+    return result
 
 
 def components(air: str, timeout: int = 15, token: str | None = None) -> dict:
-    """A version's VAE/CLIP component files for the Model Selector's extra outputs. Empty buckets
+    """A version's files classified for the Model Selector (primary + VAE/CLIP components). Empty
     for an unparseable AIR or a deleted/unknown version (404)."""
     version_id = version_id_from_air(air)
     if not version_id:
-        return {"vae": [], "clip": []}
+        return {"primary": None, "vae": [], "clip": []}
     headers = {"User-Agent": USER_AGENT, "Accept": "application/json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
     response = requests.get(CIVITAI_VERSION_URL.format(version_id=version_id), headers=headers, timeout=timeout)
     if response.status_code == 404:
-        return {"vae": [], "clip": []}
+        return {"primary": None, "vae": [], "clip": []}
     response.raise_for_status()
     return _parse_components((response.json() or {}).get("files"))

--- a/civitai_comfy_nodes/catalog.py
+++ b/civitai_comfy_nodes/catalog.py
@@ -258,4 +258,54 @@ def lookup(air: str, timeout: int = 15, token: str | None = None) -> dict | None
         "modelUrl": (
             CIVITAI_MODEL_URL.format(model_id=model_id, version_id=version_id) if model_id else None
         ),
+        "components": _parse_components(version.get("files")),
     }
+
+
+# Civitai file `type` -> the Model Selector component output it feeds. Files outside this map (the
+# primary Model/UNet, Config, Training Data, …) aren't exposed as separate component outputs.
+_FILE_TYPE_BUCKETS = {
+    "VAE": "vae",
+    "Text Encoder": "clip",
+    "TextEncoder": "clip",
+}
+
+
+def _parse_components(files: list | None) -> dict:
+    """Group a version's non-primary files into the selector's component buckets, preserving API
+    order so multiple text encoders map to clip / clip 2 / clip 3 deterministically. Each entry is
+    {id, name, downloadUrl, isRequired} — enough to label the output and download the file."""
+    buckets: dict[str, list] = {"vae": [], "clip": []}
+    for f in files or []:
+        if f.get("primary"):
+            continue
+        bucket = _FILE_TYPE_BUCKETS.get((f.get("type") or "").strip())
+        download_url = f.get("downloadUrl")
+        file_id = f.get("id")
+        if not bucket or not download_url or file_id is None:
+            continue
+        buckets[bucket].append(
+            {
+                "id": file_id,
+                "name": f.get("name") or "",
+                "downloadUrl": download_url,
+                "isRequired": bool((f.get("metadata") or {}).get("isRequired")),
+            }
+        )
+    return buckets
+
+
+def components(air: str, timeout: int = 15, token: str | None = None) -> dict:
+    """A version's VAE/CLIP component files for the Model Selector's extra outputs. Empty buckets
+    for an unparseable AIR or a deleted/unknown version (404)."""
+    version_id = version_id_from_air(air)
+    if not version_id:
+        return {"vae": [], "clip": []}
+    headers = {"User-Agent": USER_AGENT, "Accept": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    response = requests.get(CIVITAI_VERSION_URL.format(version_id=version_id), headers=headers, timeout=timeout)
+    if response.status_code == 404:
+        return {"vae": [], "clip": []}
+    response.raise_for_status()
+    return _parse_components((response.json() or {}).get("files"))

--- a/civitai_comfy_nodes/config.py
+++ b/civitai_comfy_nodes/config.py
@@ -3,7 +3,7 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import oauth
+from . import oauth, prompt_context
 from .errors import CivitaiAuthError, CivitaiNodeError
 
 DEFAULT_BASE_URL = "https://orchestration.civitai.com"
@@ -25,6 +25,9 @@ def resolve_session_id() -> str:
     CIVITAI_COMFY_SESSION_ID so submissions link to its own session; a standalone install
     instead mints one and persists it, so it survives ComfyUI restarts (identifies the instance,
     not just the process). Resolved per call so a host that sets the env var is always honoured."""
+    ctx = prompt_context.current()
+    if ctx and (ctx.get("session_id") or "").strip():
+        return ctx["session_id"].strip()
     provided = os.environ.get("CIVITAI_COMFY_SESSION_ID")
     if provided and provided.strip():
         return provided.strip()
@@ -73,9 +76,12 @@ def base_url() -> str:
 def auth_state() -> tuple[str | None, str | None]:
     """Return (token, source) from non-interactive credential sources, or (None, None).
 
-    source is one of "env", "apikey", "oauth". Never opens a browser / interactive login, so it's
-    safe for the server-side status route.
+    source is one of "prompt", "env", "apikey", "oauth". Never opens a browser / interactive login,
+    so it's safe for the server-side status route.
     """
+    ctx = prompt_context.current()
+    if ctx and ctx.get("api_token"):
+        return ctx["api_token"], "prompt"
     env = os.environ.get("CIVITAI_API_TOKEN")
     if env:
         return env, "env"

--- a/civitai_comfy_nodes/local_models.py
+++ b/civitai_comfy_nodes/local_models.py
@@ -57,20 +57,33 @@ def _model_dir(folder: str) -> str:
     return dirs[0]
 
 
-def _filename(response: requests.Response, version_id: str) -> str:
+def _filename(response: requests.Response, version_id: str, prefix: str) -> str:
     disposition = response.headers.get("content-disposition") or ""
     match = re.search(r'filename="?([^";]+)"?', disposition)
     name = match.group(1) if match else f"{version_id}.safetensors"
-    # Prefix with the version id so the cache lookup is a cheap glob and names never collide.
-    return f"civitai_{version_id}_{name}"
+    # Prefix so the cache lookup is a cheap glob and names never collide.
+    return f"{prefix}{name}"
 
 
-def download_model(air: str, folder: str = "checkpoints", token: str | None = None) -> str:
-    """Download a Civitai resource into ComfyUI's model directory; returns the local path.
-    Cached by version id, so a second use loads from disk without re-downloading."""
+def download_model(
+    air: str,
+    folder: str = "checkpoints",
+    token: str | None = None,
+    *,
+    download_url: str | None = None,
+    file_id: int | str | None = None,
+) -> str:
+    """Download a Civitai resource into ComfyUI's model directory; returns the local path. Cached so
+    a second use loads from disk. Pass `download_url` + `file_id` to fetch a specific additional file
+    of the version (e.g. a VAE or text encoder) rather than the primary file; the file id keeps the
+    cache key distinct from the primary and from sibling files that share the same folder."""
     version_id = version_id_from_air(air)
     dest_dir = _model_dir(folder)
-    cached = glob.glob(os.path.join(dest_dir, f"civitai_{version_id}_*"))
+    # Additional files key on their file id so siblings sharing a folder (e.g. a model's several
+    # text encoders, all in text_encoders/) never collide. The primary file lands in its own
+    # type folder, separate from any component folder, so its plain version glob stays unambiguous.
+    prefix = f"civitai_{version_id}_f{file_id}_" if file_id is not None else f"civitai_{version_id}_"
+    cached = glob.glob(os.path.join(dest_dir, f"{prefix}*"))
     cached = [p for p in cached if not p.endswith(".part")]
     if cached:
         return cached[0]
@@ -78,14 +91,14 @@ def download_model(air: str, folder: str = "checkpoints", token: str | None = No
     headers = {"User-Agent": USER_AGENT}
     if token:
         headers["Authorization"] = f"Bearer {token}"
-    url = CIVITAI_DOWNLOAD_URL.format(version_id=version_id)
+    url = download_url or CIVITAI_DOWNLOAD_URL.format(version_id=version_id)
     response = requests.get(url, headers=headers, stream=True, timeout=60, allow_redirects=True)
     if response.status_code >= 400:
         response.close()
         hint = " (this model may be gated — connect a Civitai Auth node)" if response.status_code in (401, 403) else ""
         raise CivitaiNodeError(f"Civitai download failed ({response.status_code}) for version {version_id}{hint}")
 
-    path = os.path.join(dest_dir, _filename(response, version_id))
+    path = os.path.join(dest_dir, _filename(response, version_id, prefix))
     tmp = path + ".part"
     total = int(response.headers.get("content-length") or 0)
     bar = comfy_compat.progress_bar(total or 100)

--- a/civitai_comfy_nodes/local_models.py
+++ b/civitai_comfy_nodes/local_models.py
@@ -47,6 +47,29 @@ def folder_for_air(air: str, default: str = "checkpoints") -> str:
     return AIR_TYPE_FOLDERS.get(air_type, default)
 
 
+# Civitai file `type` (the web app's `modelFileTypes`) -> the ComfyUI model folder. The download
+# folder follows the *file's* role, which can differ from the model's AIR type — e.g. a Checkpoint
+# model whose primary file is a "Diffusion Model" must land in diffusion_models/, not checkpoints/.
+FILE_TYPE_FOLDERS = {
+    "Model": "checkpoints",
+    "Pruned Model": "checkpoints",
+    "Diffusion Model": "diffusion_models",
+    "UNet": "diffusion_models",
+    "VAE": "vae",
+    "Text Encoder": "text_encoders",
+    "CLIPVision": "clip_vision",
+    "ControlNet": "controlnet",
+    "Upscaler": "upscale_models",
+    "Negative": "embeddings",
+}
+
+
+def folder_for_file_type(file_type: str | None, default: str = "checkpoints") -> str:
+    """The ComfyUI model folder for a Civitai file `type` (Diffusion Model -> diffusion_models, …),
+    falling back to `default` for non-model types (Config, Archive, …) or unknown ones."""
+    return FILE_TYPE_FOLDERS.get((file_type or "").strip(), default)
+
+
 def _model_dir(folder: str) -> str:
     import folder_paths
 

--- a/civitai_comfy_nodes/nodes_manual.py
+++ b/civitai_comfy_nodes/nodes_manual.py
@@ -284,9 +284,10 @@ class CivitaiModelSelector:
     RETURN_TYPES = ("CIVITAI_AIR", ANY_TYPE, ANY_TYPE, ANY_TYPE, ANY_TYPE, ANY_TYPE)
     RETURN_NAMES = ("air", "path", "clip", "vae", "clip 2", "clip 3")
     _PATH_SLOT = 1
-    # Component output slot -> (catalog.components bucket, index within that bucket, ComfyUI folder).
-    # clip before vae so the outputs line up with loaders that list clip_name above vae_name; the
-    # extra clip slots stay at the tail so single-clip models still collapse to clip + vae.
+    # Component output slot -> (catalog.components bucket, index within that bucket, fallback folder).
+    # The download folder follows each file's Civitai type; the fallback only applies if that type is
+    # missing. clip before vae so the outputs line up with loaders that list clip_name above vae_name;
+    # the extra clip slots stay at the tail so single-clip models still collapse to clip + vae.
     _COMPONENT_SLOTS = {
         2: ("clip", 0, "text_encoders"),
         3: ("vae", 0, "vae"),
@@ -336,23 +337,33 @@ class CivitaiModelSelector:
             from .config import auth_state
 
             token = (api_config or {}).get("api_token") or auth_state()[0]
+            try:
+                files = catalog.components(air, token=token)
+            except Exception:
+                files = None  # metadata fetch failed; the primary falls back, components error below
 
             if self._PATH_SLOT in consumed:
-                full = local_models.download_model(air, folder=local_models.folder_for_air(air), token=token)
+                # Folder follows the primary file's type (e.g. a Checkpoint model whose primary file
+                # is a Diffusion Model -> diffusion_models/), falling back to the AIR's type.
+                primary = (files or {}).get("primary") or {}
+                folder = local_models.folder_for_file_type(primary.get("type"), local_models.folder_for_air(air))
+                full = local_models.download_model(air, folder=folder, token=token)
                 paths[self._PATH_SLOT] = os.path.basename(full)  # folder-relative name the combo resolves
 
             component_slots = [s for s in self._COMPONENT_SLOTS if s in consumed]
             if component_slots:
-                buckets = catalog.components(air, token=token)
+                if files is None:
+                    raise CivitaiNodeError("Could not load the model's component files from Civitai.")
                 for slot in component_slots:
-                    bucket, index, folder = self._COMPONENT_SLOTS[slot]
-                    files = buckets.get(bucket) or []
-                    if index >= len(files):
+                    bucket, index, fallback_folder = self._COMPONENT_SLOTS[slot]
+                    items = files.get(bucket) or []
+                    if index >= len(items):
                         raise CivitaiNodeError(
                             f"The selected model has no file for the '{self.RETURN_NAMES[slot]}' output "
-                            f"({len(files)} {bucket} file(s) available)."
+                            f"({len(items)} {bucket} file(s) available)."
                         )
-                    f = files[index]
+                    f = items[index]
+                    folder = local_models.folder_for_file_type(f.get("type"), fallback_folder)
                     full = local_models.download_model(
                         air, folder=folder, token=token, download_url=f["downloadUrl"], file_id=f["id"]
                     )

--- a/civitai_comfy_nodes/nodes_manual.py
+++ b/civitai_comfy_nodes/nodes_manual.py
@@ -281,9 +281,16 @@ class CivitaiModelSelector:
 
     CATEGORY = "Civitai/Loaders"
     FUNCTION = "select"
-    RETURN_TYPES = ("CIVITAI_AIR", ANY_TYPE)
-    RETURN_NAMES = ("air", "path")
-    _PATH_SLOT = 1  # downloading is driven by the `path` output being wired
+    RETURN_TYPES = ("CIVITAI_AIR", ANY_TYPE, ANY_TYPE, ANY_TYPE, ANY_TYPE, ANY_TYPE)
+    RETURN_NAMES = ("air", "path", "vae", "clip", "clip 2", "clip 3")
+    _PATH_SLOT = 1
+    # Component output slot -> (catalog.components bucket, index within that bucket, ComfyUI folder).
+    _COMPONENT_SLOTS = {
+        2: ("vae", 0, "vae"),
+        3: ("clip", 0, "text_encoders"),
+        4: ("clip", 1, "text_encoders"),
+        5: ("clip", 2, "text_encoders"),
+    }
 
     @classmethod
     def INPUT_TYPES(cls):
@@ -296,40 +303,60 @@ class CivitaiModelSelector:
         }
 
     @classmethod
-    def _path_consumed(cls, prompt, unique_id) -> bool:
-        """True if the `path` output is wired downstream (so we should download the file)."""
+    def _consumed_slots(cls, prompt, unique_id) -> set:
+        """The output slots wired downstream — only those get downloaded (AIR-only use stays free)."""
+        consumed = set()
         if not prompt or unique_id is None:
-            return False
+            return consumed
         uid = str(unique_id)
         for node in prompt.values():
             for value in (node.get("inputs") or {}).values():
-                if not (isinstance(value, list) and len(value) == 2):
-                    continue
-                if str(value[0]) == uid and value[1] == cls._PATH_SLOT:
-                    return True
-        return False
+                if isinstance(value, list) and len(value) == 2 and str(value[0]) == uid:
+                    consumed.add(value[1])
+        return consumed
 
     @classmethod
     def IS_CHANGED(cls, air, api_config=None, prompt=None, unique_id=None):
-        # Re-run when `path` gets (dis)connected, not just when the AIR changes.
-        return f"{(air or '').strip()}|{cls._path_consumed(prompt, unique_id)}"
+        # Re-run when any download output gets (dis)connected, not just when the AIR changes.
+        return f"{(air or '').strip()}|{sorted(cls._consumed_slots(prompt, unique_id))}"
 
     def select(self, air, api_config=None, prompt=None, unique_id=None):
         air = (air or "").strip()
         if not air:
             raise CivitaiNodeError("No model AIR set — use the Browse Civitai button to pick one.")
-        path = ""
-        if self._path_consumed(prompt, unique_id):
+
+        consumed = self._consumed_slots(prompt, unique_id)
+        paths = {slot: "" for slot in (self._PATH_SLOT, *self._COMPONENT_SLOTS)}
+        if consumed & paths.keys():
             import os
 
-            from . import local_models
+            from . import catalog, local_models
             from .config import auth_state
 
             token = (api_config or {}).get("api_token") or auth_state()[0]
-            folder = local_models.folder_for_air(air)
-            full = local_models.download_model(air, folder=folder, token=token)
-            path = os.path.basename(full)  # folder-relative name the loader's combo resolves
-        return (air, path)
+
+            if self._PATH_SLOT in consumed:
+                full = local_models.download_model(air, folder=local_models.folder_for_air(air), token=token)
+                paths[self._PATH_SLOT] = os.path.basename(full)  # folder-relative name the combo resolves
+
+            component_slots = [s for s in self._COMPONENT_SLOTS if s in consumed]
+            if component_slots:
+                buckets = catalog.components(air, token=token)
+                for slot in component_slots:
+                    bucket, index, folder = self._COMPONENT_SLOTS[slot]
+                    files = buckets.get(bucket) or []
+                    if index >= len(files):
+                        raise CivitaiNodeError(
+                            f"The selected model has no file for the '{self.RETURN_NAMES[slot]}' output "
+                            f"({len(files)} {bucket} file(s) available)."
+                        )
+                    f = files[index]
+                    full = local_models.download_model(
+                        air, folder=folder, token=token, download_url=f["downloadUrl"], file_id=f["id"]
+                    )
+                    paths[slot] = os.path.basename(full)
+
+        return (air, paths[1], paths[2], paths[3], paths[4], paths[5])
 
 
 class CivitaiEmbeddingSelector:

--- a/civitai_comfy_nodes/nodes_manual.py
+++ b/civitai_comfy_nodes/nodes_manual.py
@@ -210,13 +210,10 @@ class CivitaiLoraLoader:
 
         # Local mode: model + clip wired in -> download and apply the whole accumulated stack.
         if model is not None and clip is not None and stack:
-            import os
+            from . import local_models
+            from .config import auth_state
 
-            from . import local_models, oauth
-
-            token = (api_config or {}).get("api_token") or os.environ.get("CIVITAI_API_TOKEN")
-            if not token:
-                token = oauth.get_valid_access_token()
+            token = (api_config or {}).get("api_token") or auth_state()[0]
             for item in stack:
                 path = local_models.download_model(item["air"], folder="loras", token=token)
                 model, clip = local_models.apply_lora(model, clip, path, item.get("strength", 1.0))
@@ -325,11 +322,10 @@ class CivitaiModelSelector:
         if self._path_consumed(prompt, unique_id):
             import os
 
-            from . import local_models, oauth
+            from . import local_models
+            from .config import auth_state
 
-            token = (api_config or {}).get("api_token") or os.environ.get("CIVITAI_API_TOKEN")
-            if not token:
-                token = oauth.get_valid_access_token()  # best-effort; public models need no token
+            token = (api_config or {}).get("api_token") or auth_state()[0]
             folder = local_models.folder_for_air(air)
             full = local_models.download_model(air, folder=folder, token=token)
             path = os.path.basename(full)  # folder-relative name the loader's combo resolves

--- a/civitai_comfy_nodes/nodes_manual.py
+++ b/civitai_comfy_nodes/nodes_manual.py
@@ -282,12 +282,14 @@ class CivitaiModelSelector:
     CATEGORY = "Civitai/Loaders"
     FUNCTION = "select"
     RETURN_TYPES = ("CIVITAI_AIR", ANY_TYPE, ANY_TYPE, ANY_TYPE, ANY_TYPE, ANY_TYPE)
-    RETURN_NAMES = ("air", "path", "vae", "clip", "clip 2", "clip 3")
+    RETURN_NAMES = ("air", "path", "clip", "vae", "clip 2", "clip 3")
     _PATH_SLOT = 1
     # Component output slot -> (catalog.components bucket, index within that bucket, ComfyUI folder).
+    # clip before vae so the outputs line up with loaders that list clip_name above vae_name; the
+    # extra clip slots stay at the tail so single-clip models still collapse to clip + vae.
     _COMPONENT_SLOTS = {
-        2: ("vae", 0, "vae"),
-        3: ("clip", 0, "text_encoders"),
+        2: ("clip", 0, "text_encoders"),
+        3: ("vae", 0, "vae"),
         4: ("clip", 1, "text_encoders"),
         5: ("clip", 2, "text_encoders"),
     }

--- a/civitai_comfy_nodes/prompt_context.py
+++ b/civitai_comfy_nodes/prompt_context.py
@@ -1,0 +1,69 @@
+"""Per-prompt Civitai credentials.
+
+A hosted runner (spine-controller) puts the session owner's token + session id
+in the ComfyUI /prompt `extra_data` under "civitai" rather than a container env
+var, because the comfy container is pooled across users. An on-prompt handler
+captures and strips it per prompt; nodes read it during their own execution,
+matched to the running prompt id (so a pooled container never crosses users).
+"""
+
+import threading
+import uuid
+
+try:
+    from server import PromptServer
+
+    _IN_COMFY = True
+except Exception:  # imported under plain pytest, no ComfyUI runtime
+    _IN_COMFY = False
+
+_MAX = 64
+_lock = threading.Lock()
+_by_prompt: dict[str, dict] = {}
+_registered = False
+
+
+def _on_prompt(json_data):
+    extra = json_data.get("extra_data")
+    civitai = extra.pop("civitai", None) if isinstance(extra, dict) else None
+    if civitai:
+        prompt_id = str(json_data.get("prompt_id") or uuid.uuid4().hex)
+        json_data["prompt_id"] = prompt_id  # the server honors a supplied id
+        with _lock:
+            _by_prompt[prompt_id] = civitai
+            while len(_by_prompt) > _MAX:
+                _by_prompt.pop(next(iter(_by_prompt)))
+    return json_data
+
+
+def register() -> None:
+    global _registered
+    if not _IN_COMFY or _registered:
+        return
+    try:
+        PromptServer.instance.add_on_prompt_handler(_on_prompt)
+        _registered = True
+    except Exception:
+        pass
+
+
+def _running_prompt_id() -> str | None:
+    if not _IN_COMFY:
+        return None
+    try:
+        for item in PromptServer.instance.prompt_queue.currently_running.values():
+            return item[1]  # (number, prompt_id, prompt, ...)
+    except Exception:
+        return None
+    return None
+
+
+def current() -> dict | None:
+    """The session owner's {api_token, session_id} for the executing prompt, or
+    None. Matched to the running prompt id — no fallback, so a credential is
+    never served to the wrong prompt."""
+    prompt_id = _running_prompt_id()
+    if prompt_id is None:
+        return None
+    with _lock:
+        return _by_prompt.get(prompt_id)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -136,6 +136,69 @@ def test_lookup_maps_model_version_to_preview(monkeypatch):
     assert entry["ecosystem"] == "sd1"
     assert entry["trainedWords"] == ["dreamshaper"]
     assert entry["modelUrl"] == "https://civitai.com/models/4384?modelVersionId=128713"
+    assert entry["components"] == {"vae": [], "clip": []}  # no extra files in this version
+
+
+def _version_resp(files):
+    class _Resp:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"id": 999, "modelId": 1, "files": files}
+
+    return _Resp()
+
+
+def test_components_groups_vae_and_clip_in_api_order(monkeypatch):
+    files = [
+        {"id": 1, "name": "model.safetensors", "type": "Model", "primary": True,
+         "downloadUrl": "https://civitai.com/api/download/models/999"},
+        {"id": 2, "name": "ae.safetensors", "type": "VAE", "primary": False,
+         "downloadUrl": "https://civitai.com/api/download/models/999?type=VAE",
+         "metadata": {"isRequired": True}},
+        {"id": 3, "name": "clip_l.safetensors", "type": "Text Encoder", "primary": False,
+         "downloadUrl": "https://civitai.com/api/download/models/999?type=Text%20Encoder&part=1"},
+        {"id": 4, "name": "t5.safetensors", "type": "Text Encoder", "primary": False,
+         "downloadUrl": "https://civitai.com/api/download/models/999?type=Text%20Encoder&part=2"},
+        {"id": 5, "name": "config.json", "type": "Config", "primary": False,
+         "downloadUrl": "https://civitai.com/api/download/models/999?type=Config"},
+    ]
+    monkeypatch.setattr(catalog.requests, "get", lambda *a, **k: _version_resp(files))
+    comps = catalog.components("urn:air:zimage:checkpoint:civitai:1@999")
+    assert [f["id"] for f in comps["vae"]] == [2]
+    assert comps["vae"][0]["isRequired"] is True
+    assert [f["name"] for f in comps["clip"]] == ["clip_l.safetensors", "t5.safetensors"]  # API order preserved
+    assert comps["clip"][0]["downloadUrl"].endswith("part=1")  # the file's own URL drives the download
+
+
+def test_components_skips_primary_and_files_without_a_download_url(monkeypatch):
+    files = [
+        {"id": 1, "name": "vae_primary", "type": "VAE", "primary": True, "downloadUrl": "u"},  # primary -> skipped
+        {"id": 2, "name": "te_no_url", "type": "Text Encoder", "primary": False},  # no downloadUrl -> skipped
+    ]
+    monkeypatch.setattr(catalog.requests, "get", lambda *a, **k: _version_resp(files))
+    assert catalog.components("urn:air:x:checkpoint:civitai:1@999") == {"vae": [], "clip": []}
+
+
+def test_components_empty_for_unparseable_air():
+    assert catalog.components("not-an-air") == {"vae": [], "clip": []}
+
+
+def test_components_empty_on_404(monkeypatch):
+    class _Resp:
+        status_code = 404
+
+        def raise_for_status(self):
+            raise AssertionError("should not raise on 404")
+
+        def json(self):
+            return {}
+
+    monkeypatch.setattr(catalog.requests, "get", lambda *a, **k: _Resp())
+    assert catalog.components("urn:air:x:checkpoint:civitai:1@999") == {"vae": [], "clip": []}
 
 
 def test_lookup_returns_none_for_unparseable_air():

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -136,7 +136,7 @@ def test_lookup_maps_model_version_to_preview(monkeypatch):
     assert entry["ecosystem"] == "sd1"
     assert entry["trainedWords"] == ["dreamshaper"]
     assert entry["modelUrl"] == "https://civitai.com/models/4384?modelVersionId=128713"
-    assert entry["components"] == {"vae": [], "clip": []}  # no extra files in this version
+    assert entry["components"] == {"primary": None, "vae": [], "clip": []}  # no files in this version
 
 
 def _version_resp(files):
@@ -168,23 +168,26 @@ def test_components_groups_vae_and_clip_in_api_order(monkeypatch):
     ]
     monkeypatch.setattr(catalog.requests, "get", lambda *a, **k: _version_resp(files))
     comps = catalog.components("urn:air:zimage:checkpoint:civitai:1@999")
+    assert comps["primary"]["id"] == 1 and comps["primary"]["type"] == "Model"  # captured whatever its type
     assert [f["id"] for f in comps["vae"]] == [2]
     assert comps["vae"][0]["isRequired"] is True
     assert [f["name"] for f in comps["clip"]] == ["clip_l.safetensors", "t5.safetensors"]  # API order preserved
     assert comps["clip"][0]["downloadUrl"].endswith("part=1")  # the file's own URL drives the download
 
 
-def test_components_skips_primary_and_files_without_a_download_url(monkeypatch):
+def test_components_captures_primary_regardless_of_type(monkeypatch):
     files = [
-        {"id": 1, "name": "vae_primary", "type": "VAE", "primary": True, "downloadUrl": "u"},  # primary -> skipped
+        {"id": 1, "name": "diff.safetensors", "type": "Diffusion Model", "primary": True, "downloadUrl": "u1"},
         {"id": 2, "name": "te_no_url", "type": "Text Encoder", "primary": False},  # no downloadUrl -> skipped
     ]
     monkeypatch.setattr(catalog.requests, "get", lambda *a, **k: _version_resp(files))
-    assert catalog.components("urn:air:x:checkpoint:civitai:1@999") == {"vae": [], "clip": []}
+    comps = catalog.components("urn:air:x:checkpoint:civitai:1@999")
+    assert comps["primary"]["type"] == "Diffusion Model"  # AIR says checkpoint, primary file says otherwise
+    assert comps["vae"] == [] and comps["clip"] == []
 
 
 def test_components_empty_for_unparseable_air():
-    assert catalog.components("not-an-air") == {"vae": [], "clip": []}
+    assert catalog.components("not-an-air") == {"primary": None, "vae": [], "clip": []}
 
 
 def test_components_empty_on_404(monkeypatch):
@@ -198,7 +201,7 @@ def test_components_empty_on_404(monkeypatch):
             return {}
 
     monkeypatch.setattr(catalog.requests, "get", lambda *a, **k: _Resp())
-    assert catalog.components("urn:air:x:checkpoint:civitai:1@999") == {"vae": [], "clip": []}
+    assert catalog.components("urn:air:x:checkpoint:civitai:1@999") == {"primary": None, "vae": [], "clip": []}
 
 
 def test_lookup_returns_none_for_unparseable_air():

--- a/tests/test_local_loader.py
+++ b/tests/test_local_loader.py
@@ -1,6 +1,6 @@
 import pytest
 
-from civitai_comfy_nodes import local_models, oauth
+from civitai_comfy_nodes import catalog, config, local_models
 from civitai_comfy_nodes.errors import CivitaiNodeError
 from civitai_comfy_nodes.nodes_manual import CivitaiModelSelector
 
@@ -32,15 +32,63 @@ def test_download_uses_disk_cache(monkeypatch, tmp_path):
     assert local_models.download_model("urn:air:x:checkpoint:civitai:1@128078") == str(cached)
 
 
-def test_path_consumed_detection():
-    consumed = CivitaiModelSelector._path_consumed
+def test_download_specific_file_keyed_by_file_id(monkeypatch, tmp_path):
+    monkeypatch.setattr(local_models, "_model_dir", lambda folder: str(tmp_path))
+    # a sibling primary file of the same version is already cached; the file-id glob must not match it
+    (tmp_path / "civitai_999_model.safetensors").write_text("primary")
+    captured = {}
+
+    class _Resp:
+        status_code = 200
+        headers = {"content-disposition": 'filename="clip_l.safetensors"', "content-length": "5"}
+
+        def iter_content(self, chunk_size=0):
+            yield b"abcde"
+
+        def close(self):
+            pass
+
+    def fake_get(url, headers=None, stream=None, timeout=None, allow_redirects=None):
+        captured["url"] = url
+        return _Resp()
+
+    monkeypatch.setattr(local_models.requests, "get", fake_get)
+    out = local_models.download_model(
+        "urn:air:zimage:checkpoint:civitai:1@999",
+        folder="text_encoders",
+        download_url="https://civitai.com/api/download/models/999?type=Text%20Encoder",
+        file_id=4,
+    )
+    assert captured["url"].endswith("type=Text%20Encoder")  # the file's own downloadUrl, not the version URL
+    assert out == str(tmp_path / "civitai_999_f4_clip_l.safetensors")  # cache name scoped by file id
+
+
+def test_download_specific_file_uses_its_own_cache(monkeypatch, tmp_path):
+    monkeypatch.setattr(local_models, "_model_dir", lambda folder: str(tmp_path))
+    (tmp_path / "civitai_999_f4_clip_l.safetensors").write_text("weights")
+
+    def boom(*a, **k):
+        raise AssertionError("hit the network despite a cached component file")
+
+    monkeypatch.setattr(local_models.requests, "get", boom)
+    out = local_models.download_model(
+        "urn:air:x:checkpoint:civitai:1@999", folder="text_encoders", download_url="u", file_id=4
+    )
+    assert out == str(tmp_path / "civitai_999_f4_clip_l.safetensors")
+
+
+def test_consumed_slots_detection():
+    consumed = CivitaiModelSelector._consumed_slots
     # node "5" takes its ckpt_name input from node "3" output slot 1 (the `path` output)
     prompt = {"5": {"inputs": {"ckpt_name": ["3", 1]}}, "6": {"inputs": {"text": "hi"}}}
-    assert consumed(prompt, "3") is True
-    assert consumed(prompt, "9") is False  # nothing references node 9
-    # only the AIR (slot 0) is consumed -> no download
-    assert consumed({"5": {"inputs": {"model_air": ["3", 0]}}}, "3") is False
-    assert consumed(None, "3") is False  # no prompt available -> don't download
+    assert consumed(prompt, "3") == {1}
+    assert consumed(prompt, "9") == set()  # nothing references node 9
+    # only the AIR (slot 0) is consumed -> no download slots
+    assert consumed({"5": {"inputs": {"model_air": ["3", 0]}}}, "3") == {0}
+    assert consumed(None, "3") == set()  # no prompt available -> don't download
+    # unet (path, slot 1), vae (slot 2) and clip (slot 3) all wired from one downstream node
+    multi = {"7": {"inputs": {"unet_name": ["3", 1], "vae_name": ["3", 2], "clip_name": ["3", 3]}}}
+    assert consumed(multi, "3") == {1, 2, 3}
 
 
 def test_is_changed_tracks_path_connection():
@@ -50,31 +98,67 @@ def test_is_changed_tracks_path_connection():
 
 
 def test_select_air_only_does_not_download(monkeypatch):
-    # No `path` wired -> returns (air, "") and never downloads.
+    # No download output wired -> returns the air plus empty paths and never downloads.
     def boom(*a, **k):
         raise AssertionError("downloaded despite AIR-only wiring")
 
     monkeypatch.setattr(local_models, "download_model", boom)
-    air, path = CivitaiModelSelector().select("  urn:air:x:checkpoint:civitai:1@2  ", prompt={}, unique_id="3")
-    assert air == "urn:air:x:checkpoint:civitai:1@2"
-    assert path == ""
+    result = CivitaiModelSelector().select("  urn:air:x:checkpoint:civitai:1@2  ", prompt={}, unique_id="3")
+    assert result[0] == "urn:air:x:checkpoint:civitai:1@2"
+    assert result[1:] == ("", "", "", "", "")  # path + vae + clip + clip 2 + clip 3 all empty
 
 
 def test_select_downloads_to_air_folder_when_path_wired(monkeypatch):
-    monkeypatch.setattr(oauth, "get_valid_access_token", lambda: None)
+    monkeypatch.setattr(config, "auth_state", lambda: (None, "none"))
     captured = {}
 
-    def fake_download(air, folder, token):
+    def fake_download(air, folder, token, **kw):
         captured["folder"] = folder
         return f"/models/{folder}/civitai_2_model.safetensors"
 
     monkeypatch.setattr(local_models, "download_model", fake_download)
     # ckpt_name on node "9" is wired to this node ("3") `path` output (slot 1)
     prompt = {"9": {"inputs": {"ckpt_name": ["3", 1]}}}
-    air, path = CivitaiModelSelector().select("urn:air:sdxl:lora:civitai:1@2", prompt=prompt, unique_id="3")
+    result = CivitaiModelSelector().select("urn:air:sdxl:lora:civitai:1@2", prompt=prompt, unique_id="3")
     assert captured["folder"] == "loras"  # folder derived from the AIR type
-    assert path == "civitai_2_model.safetensors"  # folder-relative name for the loader combo
-    assert air == "urn:air:sdxl:lora:civitai:1@2"
+    assert result[1] == "civitai_2_model.safetensors"  # folder-relative name for the loader combo
+    assert result[0] == "urn:air:sdxl:lora:civitai:1@2"
+
+
+def test_select_downloads_components_when_wired(monkeypatch):
+    monkeypatch.setattr(config, "auth_state", lambda: (None, "none"))
+    monkeypatch.setattr(
+        catalog,
+        "components",
+        lambda air, token=None: {
+            "vae": [{"id": 22, "name": "ae.safetensors", "downloadUrl": "u-vae"}],
+            "clip": [{"id": 33, "name": "clip_l.safetensors", "downloadUrl": "u-clip"}],
+        },
+    )
+    calls = []
+
+    def fake_download(air, folder, token, download_url=None, file_id=None):
+        calls.append((folder, download_url, file_id))
+        return f"/models/{folder}/civitai_9_f{file_id}_{folder}.safetensors"
+
+    monkeypatch.setattr(local_models, "download_model", fake_download)
+    # node "7" wires the vae (slot 2) and first clip (slot 3) of node "3"
+    prompt = {"7": {"inputs": {"vae_name": ["3", 2], "clip_name": ["3", 3]}}}
+    result = CivitaiModelSelector().select("urn:air:zimage:checkpoint:civitai:1@9", prompt=prompt, unique_id="3")
+    assert result[2] == "civitai_9_f22_vae.safetensors"  # vae output -> vae/ folder, keyed by file id
+    assert result[3] == "civitai_9_f33_text_encoders.safetensors"  # clip output -> text_encoders/
+    assert result[1] == ""  # path not wired -> primary not downloaded
+    assert ("vae", "u-vae", 22) in calls
+    assert ("text_encoders", "u-clip", 33) in calls
+
+
+def test_select_errors_when_a_wired_component_is_missing(monkeypatch):
+    monkeypatch.setattr(config, "auth_state", lambda: (None, "none"))
+    monkeypatch.setattr(catalog, "components", lambda air, token=None: {"vae": [], "clip": []})
+    monkeypatch.setattr(local_models, "download_model", lambda *a, **k: "/x")
+    prompt = {"7": {"inputs": {"vae_name": ["3", 2]}}}  # vae wired but the model has none
+    with pytest.raises(CivitaiNodeError):
+        CivitaiModelSelector().select("urn:air:x:checkpoint:civitai:1@9", prompt=prompt, unique_id="3")
 
 
 def _rows(*entries):

--- a/tests/test_local_loader.py
+++ b/tests/test_local_loader.py
@@ -86,8 +86,8 @@ def test_consumed_slots_detection():
     # only the AIR (slot 0) is consumed -> no download slots
     assert consumed({"5": {"inputs": {"model_air": ["3", 0]}}}, "3") == {0}
     assert consumed(None, "3") == set()  # no prompt available -> don't download
-    # unet (path, slot 1), vae (slot 2) and clip (slot 3) all wired from one downstream node
-    multi = {"7": {"inputs": {"unet_name": ["3", 1], "vae_name": ["3", 2], "clip_name": ["3", 3]}}}
+    # unet (path, slot 1), clip (slot 2) and vae (slot 3) all wired from one downstream node
+    multi = {"7": {"inputs": {"unet_name": ["3", 1], "clip_name": ["3", 2], "vae_name": ["3", 3]}}}
     assert consumed(multi, "3") == {1, 2, 3}
 
 
@@ -142,11 +142,11 @@ def test_select_downloads_components_when_wired(monkeypatch):
         return f"/models/{folder}/civitai_9_f{file_id}_{folder}.safetensors"
 
     monkeypatch.setattr(local_models, "download_model", fake_download)
-    # node "7" wires the vae (slot 2) and first clip (slot 3) of node "3"
-    prompt = {"7": {"inputs": {"vae_name": ["3", 2], "clip_name": ["3", 3]}}}
+    # node "7" wires the first clip (slot 2) and the vae (slot 3) of node "3"
+    prompt = {"7": {"inputs": {"clip_name": ["3", 2], "vae_name": ["3", 3]}}}
     result = CivitaiModelSelector().select("urn:air:zimage:checkpoint:civitai:1@9", prompt=prompt, unique_id="3")
-    assert result[2] == "civitai_9_f22_vae.safetensors"  # vae output -> vae/ folder, keyed by file id
-    assert result[3] == "civitai_9_f33_text_encoders.safetensors"  # clip output -> text_encoders/
+    assert result[2] == "civitai_9_f33_text_encoders.safetensors"  # clip output -> text_encoders/
+    assert result[3] == "civitai_9_f22_vae.safetensors"  # vae output -> vae/ folder, keyed by file id
     assert result[1] == ""  # path not wired -> primary not downloaded
     assert ("vae", "u-vae", 22) in calls
     assert ("text_encoders", "u-clip", 33) in calls
@@ -156,7 +156,7 @@ def test_select_errors_when_a_wired_component_is_missing(monkeypatch):
     monkeypatch.setattr(config, "auth_state", lambda: (None, "none"))
     monkeypatch.setattr(catalog, "components", lambda air, token=None: {"vae": [], "clip": []})
     monkeypatch.setattr(local_models, "download_model", lambda *a, **k: "/x")
-    prompt = {"7": {"inputs": {"vae_name": ["3", 2]}}}  # vae wired but the model has none
+    prompt = {"7": {"inputs": {"clip_name": ["3", 2]}}}  # clip wired but the model has none
     with pytest.raises(CivitaiNodeError):
         CivitaiModelSelector().select("urn:air:x:checkpoint:civitai:1@9", prompt=prompt, unique_id="3")
 

--- a/tests/test_local_loader.py
+++ b/tests/test_local_loader.py
@@ -20,6 +20,17 @@ def test_folder_for_air_maps_type_to_comfy_folder():
     assert local_models.folder_for_air("garbage") == "checkpoints"  # default
 
 
+def test_folder_for_file_type_maps_civitai_file_type():
+    assert local_models.folder_for_file_type("Diffusion Model") == "diffusion_models"
+    assert local_models.folder_for_file_type("UNet") == "diffusion_models"
+    assert local_models.folder_for_file_type("Model") == "checkpoints"
+    assert local_models.folder_for_file_type("VAE") == "vae"
+    assert local_models.folder_for_file_type("Text Encoder") == "text_encoders"
+    assert local_models.folder_for_file_type("CLIPVision") == "clip_vision"
+    assert local_models.folder_for_file_type("Config", "checkpoints") == "checkpoints"  # non-model -> default
+    assert local_models.folder_for_file_type(None) == "checkpoints"
+
+
 def test_download_uses_disk_cache(monkeypatch, tmp_path):
     monkeypatch.setattr(local_models, "_model_dir", lambda folder: str(tmp_path))
     cached = tmp_path / "civitai_128078_dreamshaper.safetensors"
@@ -108,8 +119,9 @@ def test_select_air_only_does_not_download(monkeypatch):
     assert result[1:] == ("", "", "", "", "")  # path + vae + clip + clip 2 + clip 3 all empty
 
 
-def test_select_downloads_to_air_folder_when_path_wired(monkeypatch):
+def test_select_path_falls_back_to_air_folder_without_primary_type(monkeypatch):
     monkeypatch.setattr(config, "auth_state", lambda: (None, "none"))
+    monkeypatch.setattr(catalog, "components", lambda air, token=None: {"primary": None, "vae": [], "clip": []})
     captured = {}
 
     def fake_download(air, folder, token, **kw):
@@ -120,9 +132,34 @@ def test_select_downloads_to_air_folder_when_path_wired(monkeypatch):
     # ckpt_name on node "9" is wired to this node ("3") `path` output (slot 1)
     prompt = {"9": {"inputs": {"ckpt_name": ["3", 1]}}}
     result = CivitaiModelSelector().select("urn:air:sdxl:lora:civitai:1@2", prompt=prompt, unique_id="3")
-    assert captured["folder"] == "loras"  # folder derived from the AIR type
+    assert captured["folder"] == "loras"  # no primary file type -> fall back to the AIR type
     assert result[1] == "civitai_2_model.safetensors"  # folder-relative name for the loader combo
     assert result[0] == "urn:air:sdxl:lora:civitai:1@2"
+
+
+def test_select_path_folder_follows_primary_file_type(monkeypatch):
+    monkeypatch.setattr(config, "auth_state", lambda: (None, "none"))
+    # AIR type says checkpoint, but the primary file is a Diffusion Model -> diffusion_models/
+    monkeypatch.setattr(
+        catalog,
+        "components",
+        lambda air, token=None: {
+            "primary": {"id": 1, "name": "m.safetensors", "type": "Diffusion Model", "downloadUrl": "u"},
+            "vae": [],
+            "clip": [],
+        },
+    )
+    captured = {}
+
+    def fake_download(air, folder, token, **kw):
+        captured["folder"] = folder
+        return f"/models/{folder}/civitai_9_m.safetensors"
+
+    monkeypatch.setattr(local_models, "download_model", fake_download)
+    prompt = {"9": {"inputs": {"unet_name": ["3", 1]}}}
+    result = CivitaiModelSelector().select("urn:air:zimage:checkpoint:civitai:1@9", prompt=prompt, unique_id="3")
+    assert captured["folder"] == "diffusion_models"  # from the FILE type, not the AIR's "checkpoint"
+    assert result[1] == "civitai_9_m.safetensors"
 
 
 def test_select_downloads_components_when_wired(monkeypatch):
@@ -131,8 +168,9 @@ def test_select_downloads_components_when_wired(monkeypatch):
         catalog,
         "components",
         lambda air, token=None: {
-            "vae": [{"id": 22, "name": "ae.safetensors", "downloadUrl": "u-vae"}],
-            "clip": [{"id": 33, "name": "clip_l.safetensors", "downloadUrl": "u-clip"}],
+            "primary": None,
+            "vae": [{"id": 22, "name": "ae.safetensors", "type": "VAE", "downloadUrl": "u-vae"}],
+            "clip": [{"id": 33, "name": "clip_l.safetensors", "type": "Text Encoder", "downloadUrl": "u-clip"}],
         },
     )
     calls = []

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -35,7 +35,7 @@ class _Node(base.CivitaiRecipeNodeBase):
 
 def test_run_logs_workflow_id_and_status_transitions(monkeypatch, caplog):
     cfg = ClientConfig("http://x", "t", timeout_minutes=30)
-    monkeypatch.setattr(base, "resolve_config", lambda api_config=None: cfg)
+    monkeypatch.setattr(base, "resolve_config", lambda api_config=None, **_: cfg)
     monkeypatch.setattr(base, "OrchestrationClient", _FakeClient)
     monkeypatch.setattr(base.CivitaiRecipeNodeBase, "_interruptible_sleep", staticmethod(lambda seconds: None))
 

--- a/web/civitai-catalog.js
+++ b/web/civitai-catalog.js
@@ -303,14 +303,56 @@ function renderPreview(node, { entry = null, air = "", sub = "", empty = false }
   st.el.title = entry?.modelUrl ? "Open on Civitai ↗" : "";
 }
 
+// Adaptive component outputs: keep the node's outputs a prefix of the canonical list
+// [air, path, vae, clip, clip 2, clip 3] so slot indices always match the Python node, growing /
+// collapsing the trailing component slots to fit the picked model and labelling each with its real
+// file. A slot with a live link is never removed (so loading a saved graph can't drop a wire).
+const COMPONENT_OUTPUTS = ["vae", "clip", "clip 2", "clip 3"]; // canonical output slots 2..5
+
+function applyComponentOutputs(node, components) {
+  if (!components || !node.outputs) return; // unknown (e.g. lookup failed) — leave outputs as they are
+  const vae = components.vae || [];
+  const clip = components.clip || [];
+  const fileFor = [vae[0], clip[0], clip[1], clip[2]]; // canonical slot 2..5 -> its file (or undefined)
+  let lastNeeded = 1; // 1 = `path`; nothing past it needed yet
+  fileFor.forEach((f, i) => { if (f) lastNeeded = Math.max(lastNeeded, 2 + i); });
+
+  let changed = false;
+  while (node.outputs.length <= lastNeeded && node.outputs.length <= 5) {
+    node.addOutput(COMPONENT_OUTPUTS[node.outputs.length - 2], "*");
+    changed = true;
+  }
+  for (let slot = node.outputs.length - 1; slot > Math.max(lastNeeded, 1); slot--) {
+    if (node.outputs[slot]?.links?.length) break; // keep a linked slot (and everything below it)
+    node.removeOutput(slot);
+    changed = true;
+  }
+  for (let slot = 2; slot < node.outputs.length; slot++) {
+    const out = node.outputs[slot];
+    if (!out) continue;
+    const f = fileFor[slot - 2];
+    out.label = f?.name ? `${COMPONENT_OUTPUTS[slot - 2]}: ${f.name}` : `${COMPONENT_OUTPUTS[slot - 2]} (none)`;
+  }
+  if (changed) {
+    node.setSize([node.size?.[0] || node.computeSize()[0], node.computeSize()[1]]);
+    node.graph?.setDirtyCanvas(true, true);
+  }
+}
+
 // Reflect the node's current `air` value: render from the stashed metadata when it matches, else
 // resolve the AIR via the lookup proxy (handles pasted AIRs and graphs saved before this existed).
+// The lookup carries the version's components, which drive the adaptive VAE/CLIP outputs.
 function refreshPreview(node, airWidget) {
   const air = (airWidget.value || "").trim();
-  if (!air) { renderPreview(node, { empty: true }); return; }
+  if (!air) { renderPreview(node, { empty: true }); applyComponentOutputs(node, { vae: [], clip: [] }); return; }
   const stored = node.properties?.civitai_model;
-  if (stored && stored.air === air) { renderPreview(node, { entry: stored }); return; }
-  renderPreview(node, { air, sub: "Loading…" });
+  if (stored && stored.air === air) {
+    renderPreview(node, { entry: stored });
+    if (stored.components) { applyComponentOutputs(node, stored.components); return; }
+    // Stored from a search pick (no component info yet) — fall through to fetch it via lookup.
+  } else {
+    renderPreview(node, { air, sub: "Loading…" });
+  }
   clearTimeout(node.__cvcLookupT);
   node.__cvcLookupT = setTimeout(async () => {
     try {
@@ -321,11 +363,14 @@ function refreshPreview(node, airWidget) {
         node.properties = node.properties || {};
         node.properties.civitai_model = data.entry;
         renderPreview(node, { entry: data.entry });
+        applyComponentOutputs(node, data.entry.components || { vae: [], clip: [] });
       } else {
         renderPreview(node, { air, sub: "Details unavailable" });
       }
     } catch {
-      if ((airWidget.value || "").trim() === air) renderPreview(node, { air, sub: "Details unavailable" });
+      if ((airWidget.value || "").trim() === air && !(stored && stored.air === air)) {
+        renderPreview(node, { air, sub: "Details unavailable" });
+      }
     }
   }, 250);
 }

--- a/web/civitai-catalog.js
+++ b/web/civitai-catalog.js
@@ -304,16 +304,16 @@ function renderPreview(node, { entry = null, air = "", sub = "", empty = false }
 }
 
 // Adaptive component outputs: keep the node's outputs a prefix of the canonical list
-// [air, path, vae, clip, clip 2, clip 3] so slot indices always match the Python node, growing /
+// [air, path, clip, vae, clip 2, clip 3] so slot indices always match the Python node, growing /
 // collapsing the trailing component slots to fit the picked model and labelling each with its real
 // file. A slot with a live link is never removed (so loading a saved graph can't drop a wire).
-const COMPONENT_OUTPUTS = ["vae", "clip", "clip 2", "clip 3"]; // canonical output slots 2..5
+const COMPONENT_OUTPUTS = ["clip", "vae", "clip 2", "clip 3"]; // canonical output slots 2..5
 
 function applyComponentOutputs(node, components) {
   if (!components || !node.outputs) return; // unknown (e.g. lookup failed) — leave outputs as they are
   const vae = components.vae || [];
   const clip = components.clip || [];
-  const fileFor = [vae[0], clip[0], clip[1], clip[2]]; // canonical slot 2..5 -> its file (or undefined)
+  const fileFor = [clip[0], vae[0], clip[1], clip[2]]; // canonical slot 2..5 -> its file (or undefined)
   let lastNeeded = 1; // 1 = `path`; nothing past it needed yet
   fileFor.forEach((f, i) => { if (f) lastNeeded = Math.max(lastNeeded, 2 + i); });
 

--- a/web/civitai-selector.js
+++ b/web/civitai-selector.js
@@ -9,6 +9,25 @@ const PLACEHOLDER = "⬇ from Civitai (downloaded on run)";
 // The selector's download outputs (primary file + extra components), all fed into loader combos.
 const DOWNLOAD_OUTPUTS = new Set(["path", "vae", "clip", "clip 2", "clip 3"]);
 
+// The component outputs carry filenames, so they're AnyType and LiteGraph offers them to *every*
+// file-name combo (unet_name, clip_name, vae_name are all the same generic COMBO type — the drag
+// highlight can't tell them apart). Guard the *completion* of an obviously-wrong wire by the target
+// widget's name: e.g. the `vae` output won't connect to a `clip_name`/`unet_name` input. `path` is
+// the primary file and stays unrestricted; unrecognized targets are always allowed (never block a
+// wire we don't understand).
+const OWN_KEYWORDS = {
+  vae: ["vae"],
+  clip: ["clip", "text_encoder", "textencoder", "encoder", "t5"],
+};
+const MODEL_KEYWORDS = ["unet", "diffusion", "ckpt", "checkpoint"];
+
+function mismatchRule(outputName) {
+  if (outputName === "vae") return { own: OWN_KEYWORDS.vae, foreign: [...OWN_KEYWORDS.clip, ...MODEL_KEYWORDS] };
+  if (outputName === "clip" || outputName === "clip 2" || outputName === "clip 3")
+    return { own: OWN_KEYWORDS.clip, foreign: [...OWN_KEYWORDS.vae, ...MODEL_KEYWORDS] };
+  return null; // path / air -> unrestricted
+}
+
 function fedComboWidget(node, slot) {
   const input = node?.inputs?.[slot];
   if (!input) return null;
@@ -21,6 +40,31 @@ app.registerExtension({
   name: "civitai.model-selector",
   async beforeRegisterNodeDef(nodeType, nodeData) {
     if (nodeData.name !== "CivitaiModelSelector") return;
+
+    const onConnectOutput = nodeType.prototype.onConnectOutput;
+    nodeType.prototype.onConnectOutput = function (outputIndex, inputType, inputObj, targetNode, targetIndex) {
+      if (onConnectOutput && onConnectOutput.apply(this, arguments) === false) return false;
+      const rule = mismatchRule(this.outputs?.[outputIndex]?.name);
+      if (!rule) return true;
+      const targetName = (inputObj?.name || targetNode?.inputs?.[targetIndex]?.name || "").toLowerCase();
+      if (!targetName) return true; // can't identify the target -> allow
+      const own = rule.own.some((k) => targetName.includes(k));
+      const foreign = rule.foreign.some((k) => targetName.includes(k));
+      if (foreign && !own) {
+        const outName = this.outputs[outputIndex].name;
+        try {
+          app.extensionManager?.toast?.add({
+            severity: "warn",
+            summary: "Civitai Model Selector",
+            detail: `The ${outName} output goes into a ${outName} input, not "${targetName}".`,
+            life: 4000,
+          });
+        } catch {}
+        return false;
+      }
+      return true;
+    };
+
     const onConnectionsChange = nodeType.prototype.onConnectionsChange;
     nodeType.prototype.onConnectionsChange = function (type, index, connected, link) {
       onConnectionsChange?.apply(this, arguments);

--- a/web/civitai-selector.js
+++ b/web/civitai-selector.js
@@ -6,6 +6,8 @@
 import { app } from "../../scripts/app.js";
 
 const PLACEHOLDER = "⬇ from Civitai (downloaded on run)";
+// The selector's download outputs (primary file + extra components), all fed into loader combos.
+const DOWNLOAD_OUTPUTS = new Set(["path", "vae", "clip", "clip 2", "clip 3"]);
 
 function fedComboWidget(node, slot) {
   const input = node?.inputs?.[slot];
@@ -23,7 +25,7 @@ app.registerExtension({
     nodeType.prototype.onConnectionsChange = function (type, index, connected, link) {
       onConnectionsChange?.apply(this, arguments);
       const OUTPUT = window.LiteGraph?.OUTPUT ?? 2;
-      if (type !== OUTPUT || !link || this.outputs?.[index]?.name !== "path") return;
+      if (type !== OUTPUT || !link || !DOWNLOAD_OUTPUTS.has(this.outputs?.[index]?.name)) return;
       const target = app.graph?.getNodeById?.(link.target_id);
       const widget = target && fedComboWidget(target, link.target_slot);
       if (!widget) return;


### PR DESCRIPTION
Introduce a mechanism to handle per-prompt Civitai credentials, eliminating the need for browser logins in hosted environments. The model selector now exposes additional VAE and CLIP component files as outputs, ensuring proper file organization based on their types. Implement safeguards against incorrect component connections by name.