### PR TITLE
Pair Civitai Link with OAuth account integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,18 @@ section at the top before bumping the version.
 ## [0.6.0] - 2026-09-04
 
 ### Added
-- Civitai Link pairs through your Civitai account: **Pair with your Civitai account** in the sidebar
-  runs the browser sign-in (asking for the Link permission) and registers this ComfyUI as a Link
-  instance — no code to copy, and the instance is revocable from civitai.com. A stable install id
-  makes re-pairing replace the same instance rather than adding one. Existing code pairings keep
-  working and can be switched to the account pairing from the panel; the instance they hold is
-  adopted, not duplicated. The pairing code stays available for ComfyUI installs the browser can't
-  reach.
+- Civitai Link pairs through your Civitai account: **Connect with Civitai** in the sidebar now asks
+  for the Link permission too and registers this ComfyUI as a Link instance right after sign-in — no
+  code to copy, and the instance is revocable from civitai.com. Signed in already? The Link panel
+  offers a one-click **Pair this ComfyUI**. A stable install id makes re-pairing replace the same
+  instance rather than adding one. Existing code pairings keep working and can be switched to the
+  account pairing from the panel; the instance they hold is adopted, not duplicated. The pairing
+  code stays available for installs the browser can't reach and for API-key connections.
 - Unpairing an account-paired instance also removes it on civitai.com.
 
 ### Changed
-- OAuth sign-in talks to `auth.civitai.com` directly instead of via civitai.com's redirect.
+- OAuth sign-in talks to `auth.civitai.com` directly instead of via civitai.com's redirect. Logins
+  made before this release don't carry the Link permission; pairing asks you to sign in once more.
 
 ## [0.5.2] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ The section matching the `pyproject.toml` version is published to the Comfy Regi
 [`.github/workflows/publish.yml`](.github/workflows/publish.yml). Add a new `## [x.y.z]`
 section at the top before bumping the version.
 
+## [0.6.0] - 2026-09-04
+
+### Added
+- Civitai Link pairs through your Civitai account: **Pair with your Civitai account** in the sidebar
+  runs the browser sign-in (asking for the Link permission) and registers this ComfyUI as a Link
+  instance — no code to copy, and the instance is revocable from civitai.com. A stable install id
+  makes re-pairing replace the same instance rather than adding one. Existing code pairings keep
+  working and can be switched to the account pairing from the panel; the instance they hold is
+  adopted, not duplicated. The pairing code stays available for ComfyUI installs the browser can't
+  reach.
+- Unpairing an account-paired instance also removes it on civitai.com.
+
+### Changed
+- OAuth sign-in talks to `auth.civitai.com` directly instead of via civitai.com's redirect.
+
 ## [0.5.2] - 2026-08-28
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,10 +69,13 @@ converts blob outputs to native Comfy types.
   like openai gpt-image-1/1.5/2 — where they ARE identical — stay one node with a dropdown.
   `engine` never collapses. When a collapsed group splits a fixed path (e.g. fal/qwen2
   create-ops vs edit-ops) the node is disambiguated by the group's lead operation.
-- OAuth: PKCE at `civitai.com/api/auth/oauth/*`, `scope` is a decimal bitmask
-  (114689 = UserRead|AIServicesRead|AIServicesWrite|BuzzRead), access 1h / refresh 30d.
-  Interactive login needs `CIVITAI_OAUTH_CLIENT_ID` (registered app with
-  `http://localhost:18188/civitai/callback` as redirect URI).
+- OAuth: PKCE at `auth.civitai.com/api/auth/oauth/*` (civitai.com only 308-redirects there),
+  `scope` is a decimal bitmask (114689 = UserRead|AIServicesRead|AIServicesWrite|BuzzRead),
+  access 1h / refresh 30d. The hub answers `invalid_scope` to any request wider than the client's
+  `allowedScopes`, so `LinkConnect` (bit 27, above `TokenScope.Full`) is requested only by Link
+  pairing (`LINK_SCOPE` = 134332417), never by the plain sign-in. Refresh never widens a token's
+  scope; only a fresh consent does. Interactive login needs `CIVITAI_OAUTH_CLIENT_ID` (registered
+  app with every port in `DEFAULT_PORTS` as `http://localhost:<port>/civitai/callback`).
 
 ## Load-bearing Civitai Link facts (verified against link-service + civitai `shared-types.ts`)
 
@@ -80,6 +83,14 @@ converts blob outputs to native Comfy types.
   (reconnects re-fire the `connect` handler); `commandStatus` sent before the join ack is dropped.
 - `upgradeKey` replaces the 6-char pairing code with a 128-hex key and the code stops working —
   persist it immediately. `kicked` means the instance was deleted: drop the key, don't rejoin.
+- Account pairing = `POST {link_url}/api/link/self` with the OAuth bearer (link-service introspects
+  it at the hub and requires the LinkConnect bit; an API key is not accepted). Body `installId`
+  (UUID v4, persisted in `~/.civitai/comfy-install-id`, stable across unpair/logout so re-pairing
+  re-keys the same instance) + optional `name` + optional `legacyKey` (the key of a code pairing,
+  6 or 128 chars, so link-service adopts that row instead of creating a second one). The key it
+  returns is already 128 chars and activated, so `upgradeKey` never fires for it. 401 is both "bad
+  token" and "token lacks LinkConnect" (deliberately indistinguishable) → drop the login and sign
+  in again; 400 = instance limit (10/user), don't retry; 503 = hub unreachable, retry.
 - python-socketio runs handlers, acks and callbacks on its read-loop thread: never `sio.call()`
   or block in a handler; every command runs on its own thread.
 - `resources:add` carries the SHA256 **uppercase**; `resources:list` must report it **lowercase**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,11 +71,13 @@ converts blob outputs to native Comfy types.
   create-ops vs edit-ops) the node is disambiguated by the group's lead operation.
 - OAuth: PKCE at `auth.civitai.com/api/auth/oauth/*` (civitai.com only 308-redirects there),
   `scope` is a decimal bitmask (114689 = UserRead|AIServicesRead|AIServicesWrite|BuzzRead),
-  access 1h / refresh 30d. The hub answers `invalid_scope` to any request wider than the client's
-  `allowedScopes`, so `LinkConnect` (bit 27, above `TokenScope.Full`) is requested only by Link
-  pairing (`LINK_SCOPE` = 134332417), never by the plain sign-in. Refresh never widens a token's
-  scope; only a fresh consent does. Interactive login needs `CIVITAI_OAUTH_CLIENT_ID` (registered
-  app with every port in `DEFAULT_PORTS` as `http://localhost:<port>/civitai/callback`).
+  access 1h / refresh 30d. The official client also grants `LinkConnect` (bit 27, above
+  `TokenScope.Full`, granted by raw SQL since the app-settings UI caps at Full), so its sign-in
+  requests `LINK_SCOPE` = 134332417 and `/civitai/auth/login` auto-pairs Link afterwards. The hub
+  answers `invalid_scope` to any request wider than the client's `allowedScopes`, so a custom
+  `CIVITAI_OAUTH_CLIENT_ID` gets the base `SCOPE` and can only pair Link with a code. Refresh never
+  widens a token's scope; only a fresh consent does. Every port in `DEFAULT_PORTS` must be a
+  registered redirect URI (`http://localhost:<port>/civitai/callback`).
 
 ## Load-bearing Civitai Link facts (verified against link-service + civitai `shared-types.ts`)
 

--- a/README.md
+++ b/README.md
@@ -136,14 +136,21 @@ the matching ComfyUI folder (`models/loras`, `models/checkpoints`, `models/diffu
 verifies its SHA256, and refreshes the model lists. The site also sees which models you already have,
 and the Model Library shows a Civitai icon next to every model it recognises (click to open it).
 
-1. On civitai.com open **Civitai Link** (the link icon in the header), add an instance and copy its
-   6-character code.
-2. In ComfyUI open the **Civitai** sidebar tab and paste the code into the **Civitai Link** panel.
+Open the **Civitai** sidebar tab and click **Pair with your Civitai account** in the **Civitai Link**
+panel. A browser opens on the machine running ComfyUI; approve the sign-in and the pairing completes
+by itself. The instance shows up under Civitai Link on civitai.com, where it can be renamed or revoked.
 
-The pairing is stored in `~/.civitai/comfy-link.json` and reconnects automatically after restarts.
-Removing a model from the site's Link panel deletes the file locally. Toggle the feature under
-**Settings › Civitai › Civitai Link**; a `CIVITAI_LINK_URL` env var (or the settings entry) points
-at a different relay. Link stays off in hosted comfy-cloud sessions.
+If ComfyUI runs on another machine (the browser can't reach it), use a pairing code instead: on
+civitai.com open **Civitai Link** (the link icon in the header), add an instance, copy its 6-character
+code and paste it into the panel. A code pairing can be switched to the account pairing later from the
+same panel.
+
+The pairing is stored in `~/.civitai/comfy-link.json` and reconnects automatically after restarts;
+`~/.civitai/comfy-install-id` identifies this install so re-pairing replaces the same instance instead
+of adding one (civitai.com allows ten per account). Removing a model from the site's Link panel deletes
+the file locally. Toggle the feature under **Settings › Civitai › Civitai Link**; a `CIVITAI_LINK_URL`
+env var (or the settings entry) points at a different relay. Link stays off in hosted comfy-cloud
+sessions.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -136,14 +136,15 @@ the matching ComfyUI folder (`models/loras`, `models/checkpoints`, `models/diffu
 verifies its SHA256, and refreshes the model lists. The site also sees which models you already have,
 and the Model Library shows a Civitai icon next to every model it recognises (click to open it).
 
-Open the **Civitai** sidebar tab and click **Pair with your Civitai account** in the **Civitai Link**
-panel. A browser opens on the machine running ComfyUI; approve the sign-in and the pairing completes
-by itself. The instance shows up under Civitai Link on civitai.com, where it can be renamed or revoked.
+Open the **Civitai** sidebar tab and click **Connect with Civitai**. The sign-in that opens in your
+browser also covers Link, so this ComfyUI pairs itself as soon as you approve. The instance shows up
+under Civitai Link on civitai.com, where it can be renamed or revoked; if you were already signed in,
+the panel offers a one-click **Pair this ComfyUI** instead.
 
-If ComfyUI runs on another machine (the browser can't reach it), use a pairing code instead: on
-civitai.com open **Civitai Link** (the link icon in the header), add an instance, copy its 6-character
-code and paste it into the panel. A code pairing can be switched to the account pairing later from the
-same panel.
+If ComfyUI runs on another machine (the browser can't reach it) or you connected with an API key, use
+a pairing code instead: on civitai.com open **Civitai Link** (the link icon in the header), add an
+instance, copy its 6-character code and paste it into the panel. A code pairing can be switched to the
+account pairing later from the same panel.
 
 The pairing is stored in `~/.civitai/comfy-link.json` and reconnects automatically after restarts;
 `~/.civitai/comfy-install-id` identifies this install so re-pairing replaces the same instance instead

--- a/civitai_comfy_nodes/config.py
+++ b/civitai_comfy_nodes/config.py
@@ -90,6 +90,7 @@ def save_pack_settings(data: dict) -> None:
     except OSError:
         pass
 
+
 def stored_enable_link() -> bool:
     return bool(load_pack_settings().get("enableLink", True))
 
@@ -111,7 +112,8 @@ def link_key_store_path() -> Path:
 
 
 def load_link_key() -> dict | None:
-    """The persisted Civitai Link pairing: ``{"key", "activated", "paired_at"}`` or None."""
+    """The persisted Civitai Link pairing: ``{"key", "activated", "instance_id", "paired_at"}`` or None.
+    ``instance_id`` is set only for pairings made through the account (OAuth) flow."""
     try:
         data = json.loads(link_key_store_path().read_text())
     except (FileNotFoundError, json.JSONDecodeError, OSError):
@@ -119,15 +121,50 @@ def load_link_key() -> dict | None:
     key = (data.get("key") or "").strip() if isinstance(data, dict) else ""
     if not key:
         return None
-    return {"key": key, "activated": bool(data.get("activated")), "paired_at": data.get("paired_at")}
+    return {
+        "key": key,
+        "activated": bool(data.get("activated")),
+        "instance_id": data.get("instance_id"),
+        "paired_at": data.get("paired_at"),
+    }
 
 
-def save_link_key(key: str, *, activated: bool) -> None:
+def save_link_key(key: str, *, activated: bool, instance_id: int | None = None) -> None:
     path = link_key_store_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    record = {"key": key, "activated": activated, "paired_at": datetime.now(timezone.utc).isoformat()}
+    record = {
+        "key": key,
+        "activated": activated,
+        "instance_id": instance_id,
+        "paired_at": datetime.now(timezone.utc).isoformat(),
+    }
     path.write_text(json.dumps(record))
     path.chmod(0o600)
+
+
+def install_id_store_path() -> Path:
+    override = os.environ.get("CIVITAI_COMFY_INSTALL_ID_STORE")
+    if override:
+        return Path(override)
+    return Path.home() / ".civitai" / "comfy-install-id"
+
+
+def install_id() -> str:
+    """A UUID v4 identifying this install to link-service, generated once and kept across unpair and
+    logout: re-pairing with the same id re-keys the same instance instead of adding one towards the
+    per-user instance limit."""
+    path = install_id_store_path()
+    try:
+        candidate = uuid.UUID(path.read_text().strip())
+        if candidate.version == 4:
+            return str(candidate)
+    except (FileNotFoundError, OSError, ValueError):
+        pass
+    fresh = str(uuid.uuid4())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(fresh)
+    path.chmod(0o600)
+    return fresh
 
 
 def clear_link_key() -> None:
@@ -135,6 +172,7 @@ def clear_link_key() -> None:
         link_key_store_path().unlink()
     except FileNotFoundError:
         pass
+
 
 _NO_CREDS_MESSAGE = (
     "No Civitai credentials. Set the CIVITAI_API_TOKEN environment variable to a token from "

--- a/civitai_comfy_nodes/link.py
+++ b/civitai_comfy_nodes/link.py
@@ -617,14 +617,16 @@ def _post_self(token: str, body: dict) -> requests.Response:
         time.sleep(delays.pop(0))
 
 
-def pair_via_oauth(name: str | None = None) -> dict:
+def pair_via_oauth(name: str | None = None, *, login: bool = True) -> dict:
     """Pair through the user's Civitai account: sign in (browser) if needed, then exchange the access
     token for an instance key. The persisted install id makes re-pairing re-key the same instance; a
     pairing made earlier with a code is sent as ``legacyKey`` so its instance is adopted, not duplicated."""
     reason = disabled_reason()
     if reason:
         raise ValueError(f"Civitai Link is {reason}")
-    token = _link_access_token(login=True)
+    token = _link_access_token(login=login)
+    if not token:
+        raise ValueError("Sign in to Civitai first")
     stored = config.load_link_key()
     body = {"installId": config.install_id(), "name": (name or "").strip() or _default_instance_name()}
     if stored and not stored.get("instance_id"):
@@ -637,6 +639,7 @@ def pair_via_oauth(name: str | None = None) -> dict:
         _log.info("Civitai Link paired instance %s via account", data.get("id"))
         reconfigure()
         return status()
+    _log.warning("Civitai Link pairing refused: HTTP %s %s", response.status_code, response.text[:300])
     if response.status_code == 401:
         # Also what a token minted before the client could grant LinkConnect gets; a fresh sign-in
         # is the only fix for both, so drop the login and let the next attempt run one.
@@ -657,17 +660,29 @@ def pair_via_oauth(name: str | None = None) -> dict:
     raise ValueError(f"Civitai Link pairing failed ({response.status_code}): {detail or response.text}")
 
 
+def pair_after_login() -> None:
+    """Best-effort pairing right after an account sign-in, so one sign-in sets up both the pack and
+    Link. Never opens a second browser flow and never fails the sign-in."""
+    if disabled_reason() or config.load_link_key():
+        return
+    try:
+        pair_via_oauth(login=False)
+    except Exception as e:
+        _log.warning("Civitai Link did not pair after sign-in: %s", e)
+
+
 def _delete_remote_instance(instance_id: int) -> None:
     token = _link_access_token(login=False)
     if not token:
         return
     try:
-        requests.delete(
+        response = requests.delete(
             f"{config.link_url()}/api/link",
             params={"id": instance_id},
             headers={"Authorization": f"Bearer {token}"},
             timeout=PAIR_HTTP_TIMEOUT,
         )
+        _log.info("Civitai Link instance %s removed on the site: HTTP %s", instance_id, response.status_code)
     except requests.RequestException:
         _log.debug("Could not remove Civitai Link instance %s on the site", instance_id, exc_info=True)
 
@@ -702,6 +717,7 @@ def status() -> dict:
         "paired": bool(stored),
         "activated": bool(stored and stored["activated"]),
         "viaAccount": bool(stored and stored.get("instance_id") is not None),
+        "auth": config.auth_state()[1],
         "keyHint": stored["key"][-4:] if stored else "",
         "url": config.link_url(),
         "urlSource": "env"

--- a/civitai_comfy_nodes/link.py
+++ b/civitai_comfy_nodes/link.py
@@ -5,11 +5,14 @@ package still imports and Link reports itself unavailable."""
 
 import logging
 import os
+import platform
 import threading
 import time
 import uuid
 
-from . import config, local_models, model_cache, model_resolve
+import requests
+
+from . import config, local_models, model_cache, model_resolve, oauth
 from . import link_protocol as proto
 
 try:
@@ -29,6 +32,8 @@ CONNECT_BACKOFF_MAX = 60.0
 LIST_PUSH_EVERY = 25
 STATUS_EVENT = "civitai.link.status"
 ACTIVITY_EVENT = "civitai.link.activity"
+PAIR_HTTP_TIMEOUT = 30
+PAIR_RETRY_DELAYS = (2.0, 4.0)
 
 
 def _default_sio():
@@ -202,7 +207,7 @@ class LinkClient:
         self.joined = False
         self.room_ready = False
         config.clear_link_key()
-        self.last_error = "civitai.com rejected this pairing — generate a new code and pair again"
+        self.last_error = "civitai.com removed this pairing — pair again"
         self._wake.set()
         self._changed()
 
@@ -576,13 +581,107 @@ def pair(code: str) -> dict:
     return status()
 
 
+def _link_access_token(*, login: bool) -> str | None:
+    """A stored OAuth access token carrying LinkConnect; with ``login`` a browser sign-in requesting
+    that scope replaces a missing or too-narrow login (tokens issued before the scope existed keep
+    their old mask through refresh, so only a fresh consent widens them)."""
+    token = oauth.get_valid_access_token()
+    if token and oauth.has_scope(oauth.stored_scope(), oauth.LINK_CONNECT):
+        return token
+    if not login:
+        return None
+    return oauth.interactive_login(scope=oauth.LINK_SCOPE)
+
+
+def _default_instance_name() -> str:
+    host = (platform.node() or "").strip()
+    return f"ComfyUI ({host})" if host else "ComfyUI"
+
+
+def _post_self(token: str, body: dict) -> requests.Response:
+    """POST /api/link/self, retrying the transient cases (hub unreachable → 503, connection errors)."""
+    url = f"{config.link_url()}/api/link/self"
+    delays = list(PAIR_RETRY_DELAYS)
+    while True:
+        try:
+            response = requests.post(
+                url, json=body, headers={"Authorization": f"Bearer {token}"}, timeout=PAIR_HTTP_TIMEOUT
+            )
+            if response.status_code != 503:
+                return response
+            last_error = "civitai.com's sign-in service is temporarily unavailable"
+        except requests.RequestException as e:
+            last_error = f"Cannot reach {config.link_url()}: {e}"
+        if not delays:
+            raise ValueError(f"{last_error} — try again in a minute")
+        time.sleep(delays.pop(0))
+
+
+def pair_via_oauth(name: str | None = None) -> dict:
+    """Pair through the user's Civitai account: sign in (browser) if needed, then exchange the access
+    token for an instance key. The persisted install id makes re-pairing re-key the same instance; a
+    pairing made earlier with a code is sent as ``legacyKey`` so its instance is adopted, not duplicated."""
+    reason = disabled_reason()
+    if reason:
+        raise ValueError(f"Civitai Link is {reason}")
+    token = _link_access_token(login=True)
+    stored = config.load_link_key()
+    body = {"installId": config.install_id(), "name": (name or "").strip() or _default_instance_name()}
+    if stored and not stored.get("instance_id"):
+        body["legacyKey"] = stored["key"]
+    response = _post_self(token, body)
+    if response.status_code == 200:
+        data = response.json()
+        key = proto.normalize_key(data.get("key"))
+        config.save_link_key(key, activated=True, instance_id=data.get("id"))
+        _log.info("Civitai Link paired instance %s via account", data.get("id"))
+        reconfigure()
+        return status()
+    if response.status_code == 401:
+        # Also what a token minted before the client could grant LinkConnect gets; a fresh sign-in
+        # is the only fix for both, so drop the login and let the next attempt run one.
+        oauth.clear_tokens()
+        raise ValueError(
+            "civitai.com did not accept this sign-in for Civitai Link — click Pair again to sign in afresh"
+        )
+    try:
+        detail = (response.json() or {}).get("error")
+    except ValueError:
+        detail = None
+    if response.status_code == 400:
+        raise ValueError(
+            "Civitai Link instance limit reached — remove an instance on civitai.com and try again"
+            if "limit" in str(detail or "").lower()
+            else f"civitai.com rejected the pairing: {detail or response.text}"
+        )
+    raise ValueError(f"Civitai Link pairing failed ({response.status_code}): {detail or response.text}")
+
+
+def _delete_remote_instance(instance_id: int) -> None:
+    token = _link_access_token(login=False)
+    if not token:
+        return
+    try:
+        requests.delete(
+            f"{config.link_url()}/api/link",
+            params={"id": instance_id},
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=PAIR_HTTP_TIMEOUT,
+        )
+    except requests.RequestException:
+        _log.debug("Could not remove Civitai Link instance %s on the site", instance_id, exc_info=True)
+
+
 def unpair() -> dict:
     global _client
     with _lock:
         client, _client = _client, None
     if client is not None:
         client.leave()
+    stored = config.load_link_key()
     config.clear_link_key()
+    if stored and stored.get("instance_id") is not None:
+        _delete_remote_instance(stored["instance_id"])
     return status()
 
 
@@ -602,6 +701,7 @@ def status() -> dict:
         "disabledReason": disabled_reason(),
         "paired": bool(stored),
         "activated": bool(stored and stored["activated"]),
+        "viaAccount": bool(stored and stored.get("instance_id") is not None),
         "keyHint": stored["key"][-4:] if stored else "",
         "url": config.link_url(),
         "urlSource": "env"

--- a/civitai_comfy_nodes/oauth.py
+++ b/civitai_comfy_nodes/oauth.py
@@ -22,9 +22,15 @@ import requests
 from . import comfy_compat
 from .errors import CivitaiNodeError
 
-OAUTH_BASE = os.environ.get("CIVITAI_OAUTH_BASE", "https://civitai.com")
+# The hub serves the OAuth endpoints; civitai.com only 308-redirects to it.
+OAUTH_BASE = os.environ.get("CIVITAI_OAUTH_BASE", "https://auth.civitai.com")
 # UserRead | AIServicesRead | AIServicesWrite | BuzzRead = 1 + 16384 + 32768 + 65536
 SCOPE = 114689
+# Opt-in bit above TokenScope.Full; link-service requires it on the token that pairs a Civitai Link
+# instance. Requested only when pairing Link, so a client whose allowedScopes lacks it (the hub
+# answers invalid_scope for any scope wider than the client's ceiling) still signs in for everything else.
+LINK_CONNECT = 1 << 27
+LINK_SCOPE = SCOPE | LINK_CONNECT
 # Registered for the official "Civitai ComfyUI Nodes" OAuth app; override for your own app.
 CLIENT_ID = os.environ.get("CIVITAI_OAUTH_CLIENT_ID", "2d61872c-9aa9-4dbc-93c3-899c222842c1")
 # Loopback callback ports the client tries, in order. EVERY one must be a registered redirect URI
@@ -106,11 +112,35 @@ def save_api_key(key: str) -> None:
 
 def clear_credentials() -> None:
     """Remove the stored manual API key and OAuth tokens (the sidebar 'disconnect')."""
-    for path in (api_key_store_path(), token_store_path()):
-        try:
-            path.unlink()
-        except FileNotFoundError:
-            pass
+    clear_api_key()
+    clear_tokens()
+
+
+def clear_api_key() -> None:
+    try:
+        api_key_store_path().unlink()
+    except FileNotFoundError:
+        pass
+
+
+def clear_tokens() -> None:
+    try:
+        token_store_path().unlink()
+    except FileNotFoundError:
+        pass
+
+
+def stored_scope() -> int | None:
+    """The scope bitmask of the stored OAuth login, or None when unknown."""
+    tokens = _load_tokens()
+    try:
+        return int((tokens or {}).get("scope"))
+    except (TypeError, ValueError):
+        return None
+
+
+def has_scope(scope: int | None, required: int) -> bool:
+    return scope is not None and (scope & required) == required
 
 
 def _store_token_response(payload: dict) -> dict:
@@ -227,7 +257,7 @@ class _CallbackHandler(http.server.BaseHTTPRequestHandler):
         pass
 
 
-def interactive_login() -> str:
+def interactive_login(scope: int = SCOPE) -> str:
     """Run the loopback PKCE flow: open a browser, capture the code, exchange and store tokens."""
     if not CLIENT_ID:
         raise CivitaiNodeError(
@@ -249,7 +279,7 @@ def interactive_login() -> str:
             "response_type": "code",
             "client_id": CLIENT_ID,
             "redirect_uri": redirect_uri,
-            "scope": SCOPE,
+            "scope": scope,
             "state": state,
             "code_challenge": challenge,
             "code_challenge_method": "S256",

--- a/civitai_comfy_nodes/oauth.py
+++ b/civitai_comfy_nodes/oauth.py
@@ -131,10 +131,13 @@ def clear_tokens() -> None:
 
 
 def stored_scope() -> int | None:
-    """The scope bitmask of the stored OAuth login, or None when unknown."""
-    tokens = _load_tokens()
+    """The scope bitmask of the stored OAuth login, or None when unknown. The token response carries
+    it as a number, a decimal string, or a one-element list of either, depending on the hub build."""
+    scope = (_load_tokens() or {}).get("scope")
+    if isinstance(scope, list):
+        scope = scope[0] if len(scope) == 1 else None
     try:
-        return int((tokens or {}).get("scope"))
+        return int(scope)
     except (TypeError, ValueError):
         return None
 

--- a/civitai_comfy_nodes/oauth.py
+++ b/civitai_comfy_nodes/oauth.py
@@ -27,12 +27,13 @@ OAUTH_BASE = os.environ.get("CIVITAI_OAUTH_BASE", "https://auth.civitai.com")
 # UserRead | AIServicesRead | AIServicesWrite | BuzzRead = 1 + 16384 + 32768 + 65536
 SCOPE = 114689
 # Opt-in bit above TokenScope.Full; link-service requires it on the token that pairs a Civitai Link
-# instance. Requested only when pairing Link, so a client whose allowedScopes lacks it (the hub
-# answers invalid_scope for any scope wider than the client's ceiling) still signs in for everything else.
+# instance. The official client grants it; a custom client set up through the app-settings UI cannot,
+# and the hub answers invalid_scope to any request wider than the client's ceiling.
 LINK_CONNECT = 1 << 27
 LINK_SCOPE = SCOPE | LINK_CONNECT
-# Registered for the official "Civitai ComfyUI Nodes" OAuth app; override for your own app.
-CLIENT_ID = os.environ.get("CIVITAI_OAUTH_CLIENT_ID", "2d61872c-9aa9-4dbc-93c3-899c222842c1")
+# Registered for the official "Civitai ComfyNodes" OAuth app; override for your own app.
+OFFICIAL_CLIENT_ID = "2d61872c-9aa9-4dbc-93c3-899c222842c1"
+CLIENT_ID = os.environ.get("CIVITAI_OAUTH_CLIENT_ID", OFFICIAL_CLIENT_ID)
 # Loopback callback ports the client tries, in order. EVERY one must be a registered redirect URI
 # on the OAuth app. They're spread across the range so a Windows reserved block (excluded port
 # range, the cause of WinError 10013) is very unlikely to cover them all. Override with
@@ -260,8 +261,14 @@ class _CallbackHandler(http.server.BaseHTTPRequestHandler):
         pass
 
 
-def interactive_login(scope: int = SCOPE) -> str:
+def login_scope() -> int:
+    return LINK_SCOPE if CLIENT_ID == OFFICIAL_CLIENT_ID else SCOPE
+
+
+def interactive_login(scope: int | None = None) -> str:
     """Run the loopback PKCE flow: open a browser, capture the code, exchange and store tokens."""
+    if scope is None:
+        scope = login_scope()
     if not CLIENT_ID:
         raise CivitaiNodeError(
             "No Civitai OAuth client id configured. Either set the CIVITAI_API_TOKEN environment variable "

--- a/civitai_comfy_nodes/server_routes.py
+++ b/civitai_comfy_nodes/server_routes.py
@@ -392,6 +392,7 @@ if _server is not None:
             await loop.run_in_executor(None, oauth.interactive_login)
         except Exception as e:
             return web.json_response({"error": str(e)}, status=502)
+        await loop.run_in_executor(None, link.pair_after_login)
         return web.json_response({"ok": True})
 
     @_server.routes.post("/civitai/auth/logout")

--- a/civitai_comfy_nodes/server_routes.py
+++ b/civitai_comfy_nodes/server_routes.py
@@ -392,7 +392,7 @@ if _server is not None:
             await loop.run_in_executor(None, oauth.interactive_login)
         except Exception as e:
             return web.json_response({"error": str(e)}, status=502)
-        await loop.run_in_executor(None, link.pair_after_login)
+        loop.run_in_executor(None, link.pair_after_login)
         return web.json_response({"ok": True})
 
     @_server.routes.post("/civitai/auth/logout")

--- a/civitai_comfy_nodes/server_routes.py
+++ b/civitai_comfy_nodes/server_routes.py
@@ -9,7 +9,7 @@ import re
 import uuid
 
 from . import catalog, link
-from .errors import CivitaiAuthError
+from .errors import CivitaiAuthError, CivitaiNodeError
 
 _log = logging.getLogger("civitai_comfy_nodes.server_routes")
 
@@ -278,6 +278,10 @@ def _link_pair(body: dict) -> dict:
     return link.pair(str((body or {}).get("code") or ""))
 
 
+def _link_pair_via_account(body: dict) -> dict:
+    return link.pair_via_oauth(name=str((body or {}).get("name") or ""))
+
+
 _AIR_IDS_RE = re.compile(r":civitai:(\d+)@(\d+)")
 
 
@@ -427,6 +431,16 @@ if _server is not None:
         try:
             payload = await loop.run_in_executor(None, lambda: _link_pair(body))
         except ValueError as e:
+            return web.json_response({"error": str(e)}, status=400)
+        return web.json_response(payload)
+
+    @_server.routes.post("/civitai/link/pair-account")
+    async def _civitai_link_pair_account(request):
+        body = await request.json() if request.can_read_body else {}
+        loop = asyncio.get_event_loop()
+        try:
+            payload = await loop.run_in_executor(None, lambda: _link_pair_via_account(body))
+        except (ValueError, CivitaiNodeError) as e:
             return web.json_response({"error": str(e)}, status=400)
         return web.json_response(payload)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "civitai-comfy-nodes"
-version = "0.5.2"
+version = "0.6.0"
 description = "ComfyUI custom nodes for the Civitai Orchestration API — run Civitai recipes (image/video/audio generation, training, analysis) from inside ComfyUI"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,7 @@
+import os
+import stat
+import uuid
+
 import pytest
 
 from civitai_comfy_nodes import config, oauth
@@ -124,3 +128,19 @@ def test_is_hosted_session_follows_the_pinned_session_env(link_store, monkeypatc
     assert config.is_hosted_session() is False
     monkeypatch.setenv("CIVITAI_COMFY_SESSION_ID", " cloud ")
     assert config.is_hosted_session() is True
+
+
+def test_install_id_is_a_stable_private_uuid4(tmp_path, monkeypatch):
+    from civitai_comfy_nodes import config
+
+    path = tmp_path / "install-id"
+    monkeypatch.setenv("CIVITAI_COMFY_INSTALL_ID_STORE", str(path))
+    first = config.install_id()
+    assert uuid.UUID(first).version == 4
+    assert config.install_id() == first and path.read_text() == first
+    assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
+    path.write_text("not-a-uuid")
+    regenerated = config.install_id()
+    assert regenerated != first and uuid.UUID(regenerated).version == 4
+    path.write_text(str(uuid.uuid1()))
+    assert uuid.UUID(config.install_id()).version == 4

--- a/tests/test_link_client.py
+++ b/tests/test_link_client.py
@@ -164,7 +164,7 @@ def test_upgrade_key_is_persisted_activated_and_private(env, tmp_path):
     client._bind(fake)
     fake.handlers["upgradeKey"]({"key": "f" * 128})
     stored = config.load_link_key()
-    assert stored == {"key": "f" * 128, "activated": True, "paired_at": stored["paired_at"]}
+    assert stored == {"key": "f" * 128, "activated": True, "instance_id": None, "paired_at": stored["paired_at"]}
     assert stat.S_IMODE(os.stat(tmp_path / "link.json").st_mode) == 0o600
     assert client.status()["keyHint"] == "ffff" and client.status()["activated"]
 
@@ -547,14 +547,164 @@ class FakeLinkClient:
 
 
 @pytest.fixture()
-def singleton(env, monkeypatch):
+def singleton(env, monkeypatch, tmp_path):
     FakeLinkClient.instances.clear()
     monkeypatch.setattr(link, "LinkClient", FakeLinkClient)
     monkeypatch.setattr(link, "HAVE_SOCKETIO", True)
     monkeypatch.setattr(link, "_client", None)
     monkeypatch.setattr(link, "_registered", False)
+    monkeypatch.setenv("CIVITAI_COMFY_INSTALL_ID_STORE", str(tmp_path / "install-id"))
+    monkeypatch.setenv("CIVITAI_COMFY_OAUTH_STORE", str(tmp_path / "oauth.json"))
+    monkeypatch.setattr(link, "PAIR_RETRY_DELAYS", (0.0,))
     yield
     link._client = None
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+@pytest.fixture()
+def account(singleton, monkeypatch):
+    """Stored OAuth login that already carries LinkConnect, plus a scripted link-service."""
+    from civitai_comfy_nodes import oauth
+
+    calls = []
+    responses = []
+
+    def post(url, json=None, headers=None, timeout=None):
+        calls.append({"method": "POST", "url": url, "json": json, "headers": headers})
+        return responses.pop(0)
+
+    def delete(url, params=None, headers=None, timeout=None):
+        calls.append({"method": "DELETE", "url": url, "params": params, "headers": headers})
+        return FakeResponse(200, {"success": True})
+
+    monkeypatch.setattr(link.requests, "post", post)
+    monkeypatch.setattr(link.requests, "delete", delete)
+    monkeypatch.setattr(link.oauth, "interactive_login", lambda scope=None: pytest.fail("unexpected browser login"))
+    oauth._save_tokens(
+        {
+            "access_token": "civitai_tok",
+            "refresh_token": "r",
+            "expires_at": time.time() + 3600,
+            "scope": oauth.LINK_SCOPE,
+        }
+    )
+    return calls, responses
+
+
+def test_pair_via_account_exchanges_the_token_for_a_full_key(account):
+    calls, responses = account
+    responses.append(FakeResponse(200, {"id": 834, "key": "A" * 128, "name": "ComfyUI (box)"}))
+    status = link.pair_via_oauth(name="ComfyUI (box)")
+    sent = calls[0]
+    assert sent["url"] == "https://link.civitai.com/api/link/self"
+    assert sent["headers"] == {"Authorization": "Bearer civitai_tok"}
+    assert sent["json"] == {"installId": config.install_id(), "name": "ComfyUI (box)"}  # no legacyKey: never paired
+    stored = config.load_link_key()
+    assert stored["key"] == "a" * 128 and stored["activated"] is True and stored["instance_id"] == 834
+    assert FakeLinkClient.instances[-1].kwargs["key"] == "a" * 128 and FakeLinkClient.instances[-1].started
+    assert status["paired"] and status["viaAccount"] and status["activated"]
+    # Re-pairing reuses the persisted install id, which is what keeps the instance count flat.
+    responses.append(FakeResponse(200, {"id": 834, "key": "b" * 128, "name": "ComfyUI (box)"}))
+    link.pair_via_oauth()
+    assert calls[1]["json"]["installId"] == sent["json"]["installId"]
+    assert "legacyKey" not in calls[1]["json"]
+
+
+def test_pair_via_account_adopts_a_code_pairing(account):
+    calls, responses = account
+    config.save_link_key("a1b2c3", activated=False)
+    responses.append(FakeResponse(200, {"id": 12, "key": "c" * 128, "name": None}))
+    link.pair_via_oauth()
+    assert calls[0]["json"]["legacyKey"] == "a1b2c3"
+    assert config.load_link_key()["instance_id"] == 12
+    config.save_link_key("d" * 128, activated=True)  # upgraded by the socket, still no instance id
+    responses.append(FakeResponse(200, {"id": 12, "key": "e" * 128, "name": None}))
+    link.pair_via_oauth()
+    assert calls[1]["json"]["legacyKey"] == "d" * 128
+
+
+def test_pair_via_account_signs_in_when_the_login_lacks_link_scope(account, monkeypatch):
+    from civitai_comfy_nodes import oauth
+
+    calls, responses = account
+    oauth._save_tokens({"access_token": "old", "refresh_token": "r", "expires_at": time.time() + 3600, "scope": 114689})
+    requested = []
+
+    def login(scope=None):
+        requested.append(scope)
+        oauth._save_tokens({"access_token": "fresh", "expires_at": time.time() + 3600, "scope": oauth.LINK_SCOPE})
+        return "fresh"
+
+    monkeypatch.setattr(link.oauth, "interactive_login", login)
+    responses.append(FakeResponse(200, {"id": 1, "key": "f" * 128, "name": "x"}))
+    link.pair_via_oauth()
+    assert requested == [oauth.LINK_SCOPE]
+    assert calls[0]["headers"]["Authorization"] == "Bearer fresh"
+    # No stored login at all takes the same path.
+    oauth.clear_tokens()
+    responses.append(FakeResponse(200, {"id": 1, "key": "f" * 128, "name": "x"}))
+    link.pair_via_oauth()
+    assert requested == [oauth.LINK_SCOPE, oauth.LINK_SCOPE]
+
+
+def test_pair_via_account_401_drops_the_login(account):
+    from civitai_comfy_nodes import oauth
+
+    calls, responses = account
+    responses.append(FakeResponse(401, {"error": "unauthorized"}))
+    with pytest.raises(ValueError, match="sign in afresh"):
+        link.pair_via_oauth()
+    assert oauth.get_valid_access_token() is None
+    assert config.load_link_key() is None and FakeLinkClient.instances == []
+
+
+def test_pair_via_account_reports_the_instance_limit_without_retrying(account):
+    calls, responses = account
+    responses.append(FakeResponse(400, {"error": "Instance limit reached"}))
+    with pytest.raises(ValueError, match="instance limit"):
+        link.pair_via_oauth()
+    assert len(calls) == 1
+
+
+def test_pair_via_account_retries_503_then_gives_up(account):
+    calls, responses = account
+    responses.extend([FakeResponse(503, {"error": "hub_unavailable"}), FakeResponse(503, {"error": "hub_unavailable"})])
+    with pytest.raises(ValueError, match="temporarily unavailable"):
+        link.pair_via_oauth()
+    assert len(calls) == 2
+    responses.extend(
+        [FakeResponse(503, {"error": "hub_unavailable"}), FakeResponse(200, {"id": 2, "key": "9" * 128, "name": "x"})]
+    )
+    assert link.pair_via_oauth()["paired"]
+
+
+def test_pair_via_account_respects_disabled(account):
+    config.save_pack_settings({"enableLink": False})
+    with pytest.raises(ValueError, match="disabled"):
+        link.pair_via_oauth()
+
+
+def test_unpair_removes_an_account_instance_on_the_site_only(account):
+    calls, responses = account
+    config.save_link_key("a1b2c3", activated=False)
+    link.unpair()
+    assert calls == []  # a code pairing has no instance id to delete
+    responses.append(FakeResponse(200, {"id": 7, "key": "1" * 128, "name": "x"}))
+    link.pair_via_oauth()
+    assert link.unpair()["paired"] is False
+    assert calls[-1]["method"] == "DELETE" and calls[-1]["params"] == {"id": 7}
+    assert calls[-1]["url"] == "https://link.civitai.com/api/link"
 
 
 def test_pair_validates_saves_and_starts_a_client(singleton):

--- a/tests/test_link_client.py
+++ b/tests/test_link_client.py
@@ -689,6 +689,28 @@ def test_pair_via_account_retries_503_then_gives_up(account):
     assert link.pair_via_oauth()["paired"]
 
 
+def test_pair_after_login_never_opens_a_browser_and_never_raises(account, monkeypatch):
+    from civitai_comfy_nodes import oauth
+
+    calls, responses = account
+    oauth._save_tokens({"access_token": "old", "expires_at": time.time() + 3600, "scope": 114689})
+    link.pair_after_login()  # narrow login: nothing to do, no browser
+    assert calls == [] and config.load_link_key() is None
+    oauth._save_tokens({"access_token": "wide", "expires_at": time.time() + 3600, "scope": oauth.LINK_SCOPE})
+    responses.append(FakeResponse(400, {"error": "Instance limit reached"}))
+    link.pair_after_login()  # failure is logged, not raised
+    assert config.load_link_key() is None
+    responses.append(FakeResponse(200, {"id": 5, "key": "5" * 128, "name": "x"}))
+    link.pair_after_login()
+    assert config.load_link_key()["instance_id"] == 5
+    link.pair_after_login()  # already paired: no call
+    assert len(calls) == 2
+
+
+def test_status_reports_the_auth_source(account):
+    assert link.status()["auth"] == "oauth"
+
+
 def test_pair_via_account_respects_disabled(account):
     config.save_pack_settings({"enableLink": False})
     with pytest.raises(ValueError, match="disabled"):

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -74,6 +74,13 @@ def test_link_scope_adds_only_the_link_connect_bit():
     assert not oauth.has_scope(None, oauth.LINK_CONNECT)
 
 
+def test_login_scope_requests_link_only_for_the_official_client(monkeypatch):
+    monkeypatch.setattr(oauth, "CLIENT_ID", oauth.OFFICIAL_CLIENT_ID)
+    assert oauth.login_scope() == oauth.LINK_SCOPE
+    monkeypatch.setattr(oauth, "CLIENT_ID", "someone-elses-app")
+    assert oauth.login_scope() == oauth.SCOPE
+
+
 def test_stored_scope_reads_number_or_string_and_tolerates_absence(token_store):
     assert oauth.stored_scope() is None
     token_store.write_text(json.dumps({"access_token": "a", "expires_at": 0, "scope": "114689"}))

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -67,6 +67,32 @@ def test_failed_refresh_returns_none(token_store, monkeypatch):
     assert oauth.get_valid_access_token() is None
 
 
+def test_link_scope_adds_only_the_link_connect_bit():
+    assert oauth.LINK_CONNECT == 134217728 and oauth.LINK_SCOPE == 134332417
+    assert oauth.has_scope(oauth.LINK_SCOPE, oauth.LINK_CONNECT)
+    assert not oauth.has_scope(oauth.SCOPE, oauth.LINK_CONNECT)
+    assert not oauth.has_scope(None, oauth.LINK_CONNECT)
+
+
+def test_stored_scope_reads_number_or_string_and_tolerates_absence(token_store):
+    assert oauth.stored_scope() is None
+    token_store.write_text(json.dumps({"access_token": "a", "expires_at": 0, "scope": "114689"}))
+    assert oauth.stored_scope() == 114689
+    token_store.write_text(json.dumps({"access_token": "a", "expires_at": 0, "scope": 134332417}))
+    assert oauth.stored_scope() == 134332417
+    token_store.write_text(json.dumps({"access_token": "a", "expires_at": 0}))
+    assert oauth.stored_scope() is None
+
+
+def test_clear_tokens_leaves_the_api_key_alone(token_store, tmp_path, monkeypatch):
+    monkeypatch.setenv("CIVITAI_COMFY_API_KEY_STORE", str(tmp_path / "api-key"))
+    oauth.save_api_key("civitai_key")
+    token_store.write_text("{}")
+    oauth.clear_tokens()
+    oauth.clear_tokens()
+    assert not token_store.exists() and oauth.stored_api_key() == "civitai_key"
+
+
 def test_store_permissions(token_store, monkeypatch):
     oauth._save_tokens({"access_token": "x"})
     assert oauth.token_store_path().stat().st_mode & 0o777 == 0o600

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -80,6 +80,8 @@ def test_stored_scope_reads_number_or_string_and_tolerates_absence(token_store):
     assert oauth.stored_scope() == 114689
     token_store.write_text(json.dumps({"access_token": "a", "expires_at": 0, "scope": 134332417}))
     assert oauth.stored_scope() == 134332417
+    token_store.write_text(json.dumps({"access_token": "a", "expires_at": 0, "scope": ["114689"]}))
+    assert oauth.stored_scope() == 114689
     token_store.write_text(json.dumps({"access_token": "a", "expires_at": 0}))
     assert oauth.stored_scope() is None
 

--- a/web/civitai-gallery.js
+++ b/web/civitai-gallery.js
@@ -394,7 +394,11 @@ async function init(el) {
   try {
     const status = await (await fetch("/civitai/auth/status")).json();
     if (status.authenticated) renderGallery(body);
-    else renderConnect(body, () => renderGallery(body));
+    else
+      renderConnect(body, () => {
+        renderGallery(body);
+        window.civitaiLink?.refresh();
+      });
   } catch (e) {
     body.innerHTML = `<div class="cvg-msg">Civitai gallery unavailable: ${esc(e.message || e)}</div>`;
   }

--- a/web/civitai-link.js
+++ b/web/civitai-link.js
@@ -200,6 +200,27 @@ function updateRailBadge(flash) {
 
 let showCodeEntry = false;
 
+function pairingMarkup(auth) {
+  const codeEntry = `
+        <div class="cvl-row"><input class="cvl-code" maxlength="6" placeholder="6-char code" autocomplete="off" spellcheck="false" />
+          <button class="cvl-btn cvl-pair">Pair</button></div>
+        <div class="cvl-hint">On civitai.com open <b>Civitai Link</b> (the link icon in the header), add an instance and paste its
+          code here. <a href="${LINK_HELP_URL}" target="_blank" rel="noopener">Account ↗</a></div>`;
+  const codeToggle = '<button class="cvl-link cvl-show-code">Use a pairing code instead</button>';
+  if (auth === "oauth")
+    return `
+        <div class="cvl-row"><button class="cvl-btn primary cvl-pair-account">Pair this ComfyUI</button></div>
+        <div class="cvl-hint">Adds this ComfyUI to Civitai Link on your account. Models you send from the site land in the
+          matching <code>models/</code> folder. ${showCodeEntry ? "" : codeToggle}</div>${showCodeEntry ? codeEntry : ""}`;
+  if (auth)
+    return `
+        <div class="cvl-hint">You're connected with an API key. Link pairs with your account — sign in below with
+          <b>Connect with Civitai</b> — or with a code:</div>${codeEntry}`;
+  return `
+        <div class="cvl-hint">Sign in below with <b>Connect with Civitai</b> and this ComfyUI pairs automatically.
+          ${showCodeEntry ? "" : '<button class="cvl-link cvl-show-code">ComfyUI runs on another machine? Use a pairing code</button>'}</div>${showCodeEntry ? codeEntry : ""}`;
+}
+
 function render() {
   if (!panelEl) return;
   if (isHostedSession() || (state && state.hosted)) {
@@ -211,25 +232,17 @@ function render() {
   const paired = !!(state && state.paired);
   const viaAccount = !!(state && state.viaAccount);
   const canPair = !!(state && state.available && state.enabled);
+  const auth = state?.auth || null;
   panelEl.innerHTML = `
     <div class="cvl-panel">
       <div class="cvl-head"><span class="cvl-dot ${tone}"></span><span class="cvl-title">Civitai Link</span>
         <span class="cvl-status" title="${esc(text)}">${esc(text)}</span>
         ${paired ? '<button class="cvl-btn cvl-unpair" title="Forget this pairing">Unpair</button>' : ""}
       </div>
-      ${!paired && canPair ? `
-        <div class="cvl-row"><button class="cvl-btn primary cvl-pair-account">Pair with your Civitai account</button></div>
-        <div class="cvl-hint">Approve ComfyUI in the browser that opens on this machine. Models you send from the site land in
-          the matching <code>models/</code> folder.
-          ${showCodeEntry ? "" : '<button class="cvl-link cvl-show-code">ComfyUI runs on another machine? Use a pairing code</button>'}</div>
-        ${showCodeEntry ? `
-        <div class="cvl-row"><input class="cvl-code" maxlength="6" placeholder="6-char code" autocomplete="off" spellcheck="false" />
-          <button class="cvl-btn cvl-pair">Pair</button></div>
-        <div class="cvl-hint">On civitai.com open <b>Civitai Link</b> (the link icon in the header), add an instance and paste its
-          code here. <a href="${LINK_HELP_URL}" target="_blank" rel="noopener">Account ↗</a></div>` : ""}` : ""}
-      ${paired && !viaAccount && canPair ? `
+      ${!paired && canPair ? pairingMarkup(auth) : ""}
+      ${paired && !viaAccount && canPair && auth === "oauth" ? `
         <div class="cvl-legacy"><span>Paired with a code.</span>
-          <button class="cvl-btn cvl-pair-account" title="Sign in so this pairing is tied to your account and revocable from civitai.com">Switch to account pairing</button></div>` : ""}
+          <button class="cvl-btn cvl-pair-account" title="Tie this pairing to your account so it can be revoked from civitai.com">Switch to account pairing</button></div>` : ""}
       <div class="cvl-err"></div>
       ${activityMarkup()}
     </div>`;
@@ -274,7 +287,7 @@ function render() {
   accountBtn?.addEventListener("click", async () => {
     accountBtn.disabled = true;
     err.className = "cvl-err note";
-    err.textContent = "Complete the Civitai sign-in in your browser… this pairs automatically once approved.";
+    err.textContent = "Pairing… if a Civitai sign-in opens in your browser, approve it to continue.";
     try {
       await applyPairResult(await fetch("/civitai/link/pair-account", { method: "POST" }));
       toast("success", "Civitai Link paired", "This ComfyUI is linked to your Civitai account.");
@@ -361,7 +374,11 @@ function handleActivity(r) {
   render();
 }
 
-window.civitaiLink = { renderPanel };
+async function refresh() {
+  if (panelEl) await renderPanel(panelEl);
+}
+
+window.civitaiLink = { renderPanel, refresh };
 
 app.registerExtension({
   name: "civitai.link",

--- a/web/civitai-link.js
+++ b/web/civitai-link.js
@@ -28,6 +28,11 @@ function injectStyles() {
     .cvl-hint { color: #a1a1aa; font-size: 12px; line-height: 1.4; }
     .cvl-hint a { color: #60a5fa; }
     .cvl-err { color: #f87171; font-size: 12px; }
+    .cvl-err.note { color: #a1a1aa; }
+    .cvl-link { background: none; border: none; padding: 0; color: #60a5fa; font: inherit; font-size: 12px; cursor: pointer; }
+    .cvl-link:hover { text-decoration: underline; }
+    .cvl-legacy { display: flex; align-items: center; gap: 8px; font-size: 12px; color: #a1a1aa; }
+    .cvl-legacy .cvl-btn { padding: 3px 8px; font-size: 12px; }
     .cvl-act { display: flex; flex-direction: column; gap: 2px; }
     .cvl-item { display: flex; flex-direction: column; gap: 4px; font-size: 12px; padding: 5px 6px;
       border-radius: 6px; background: #1f1f23; }
@@ -193,6 +198,8 @@ function updateRailBadge(flash) {
   if (!/done|error/.test(badge.className)) badge.className = "cvl-rail-badge";
 }
 
+let showCodeEntry = false;
+
 function render() {
   if (!panelEl) return;
   if (isHostedSession() || (state && state.hosted)) {
@@ -202,6 +209,7 @@ function render() {
   injectStyles();
   const [tone, text] = statusLine();
   const paired = !!(state && state.paired);
+  const viaAccount = !!(state && state.viaAccount);
   const canPair = !!(state && state.available && state.enabled);
   panelEl.innerHTML = `
     <div class="cvl-panel">
@@ -210,32 +218,45 @@ function render() {
         ${paired ? '<button class="cvl-btn cvl-unpair" title="Forget this pairing">Unpair</button>' : ""}
       </div>
       ${!paired && canPair ? `
+        <div class="cvl-row"><button class="cvl-btn primary cvl-pair-account">Pair with your Civitai account</button></div>
+        <div class="cvl-hint">Approve ComfyUI in the browser that opens on this machine. Models you send from the site land in
+          the matching <code>models/</code> folder.
+          ${showCodeEntry ? "" : '<button class="cvl-link cvl-show-code">ComfyUI runs on another machine? Use a pairing code</button>'}</div>
+        ${showCodeEntry ? `
         <div class="cvl-row"><input class="cvl-code" maxlength="6" placeholder="6-char code" autocomplete="off" spellcheck="false" />
-          <button class="cvl-btn primary cvl-pair">Pair</button></div>
+          <button class="cvl-btn cvl-pair">Pair</button></div>
         <div class="cvl-hint">On civitai.com open <b>Civitai Link</b> (the link icon in the header), add an instance and paste its
-          code here. Models you send from the site land in the matching <code>models/</code> folder.
-          <a href="${LINK_HELP_URL}" target="_blank" rel="noopener">Account ↗</a></div>` : ""}
+          code here. <a href="${LINK_HELP_URL}" target="_blank" rel="noopener">Account ↗</a></div>` : ""}` : ""}
+      ${paired && !viaAccount && canPair ? `
+        <div class="cvl-legacy"><span>Paired with a code.</span>
+          <button class="cvl-btn cvl-pair-account" title="Sign in so this pairing is tied to your account and revocable from civitai.com">Switch to account pairing</button></div>` : ""}
       <div class="cvl-err"></div>
       ${activityMarkup()}
     </div>`;
   const err = panelEl.querySelector(".cvl-err");
   const pairBtn = panelEl.querySelector(".cvl-pair");
   const input = panelEl.querySelector(".cvl-code");
+  const accountBtn = panelEl.querySelector(".cvl-pair-account");
+  const applyPairResult = async (res) => {
+    const data = await res.json();
+    if (!res.ok || data.error) throw new Error(data.error || res.status);
+    state = data;
+    render();
+  };
   const pair = async () => {
     const code = (input?.value || "").trim();
     if (!code) return;
     pairBtn.disabled = true;
+    err.className = "cvl-err";
     err.textContent = "";
     try {
-      const res = await fetch("/civitai/link/pair", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ code }),
-      });
-      const data = await res.json();
-      if (!res.ok || data.error) throw new Error(data.error || res.status);
-      state = data;
-      render();
+      await applyPairResult(
+        await fetch("/civitai/link/pair", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ code }),
+        })
+      );
     } catch (e) {
       err.textContent = String(e.message || e);
       pairBtn.disabled = false;
@@ -244,6 +265,24 @@ function render() {
   pairBtn?.addEventListener("click", pair);
   input?.addEventListener("keydown", (e) => {
     if (e.key === "Enter") pair();
+  });
+  panelEl.querySelector(".cvl-show-code")?.addEventListener("click", () => {
+    showCodeEntry = true;
+    render();
+    panelEl.querySelector(".cvl-code")?.focus();
+  });
+  accountBtn?.addEventListener("click", async () => {
+    accountBtn.disabled = true;
+    err.className = "cvl-err note";
+    err.textContent = "Complete the Civitai sign-in in your browser… this pairs automatically once approved.";
+    try {
+      await applyPairResult(await fetch("/civitai/link/pair-account", { method: "POST" }));
+      toast("success", "Civitai Link paired", "This ComfyUI is linked to your Civitai account.");
+    } catch (e) {
+      err.className = "cvl-err";
+      err.textContent = String(e.message || e);
+      accountBtn.disabled = false;
+    }
   });
   for (const btn of panelEl.querySelectorAll(".cvl-cancel")) {
     btn.addEventListener("click", async () => {


### PR DESCRIPTION
Introduce OAuth-based pairing for Civitai Link, allowing users to connect their ComfyUI directly through their Civitai account. This update simplifies the sign-in process, enabling automatic pairing after authentication and maintaining a stable install ID for seamless re-pairing. Adjustments to the OAuth flow enhance security and user experience, while existing pairing methods remain supported.